### PR TITLE
patch: Update contract archiving terminology and icon

### DIFF
--- a/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ChangeContractStatusModals/ContractDeleteModal.tsx
+++ b/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ChangeContractStatusModals/ContractDeleteModal.tsx
@@ -35,7 +35,7 @@ export const ContractDeleteModal = observer(
           <div>
             <div>
               <h1 className={cn('text-base font-semibold')}>
-                Delete this contract?
+                Archive this contract?
               </h1>
             </div>
             <div className='flex flex-col'>

--- a/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractCardActions/ContractMenu.tsx
+++ b/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractCardActions/ContractMenu.tsx
@@ -75,7 +75,7 @@ export const ContractMenu = ({
             onClick={() => onStatusModalOpen(ContractStatusModalMode.Delete)}
           >
             <Icon
-              name='trash-01'
+              name='archive'
               className='text-grayModern-500 group-hover:text-grayModern-700'
             />
             Archive contract


### PR DESCRIPTION
- Change "Delete" to "Archive" in ContractDeleteModal heading
- Replace 'trash-01' icon with 'archive' icon in ContractMenu
- Improve user interface language for contract archiving action