### PR TITLE
patch: Modernize date handling in UpcomingInvoice and DateTimeUtils

### DIFF
--- a/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/UpcomingInvoices/UpcomingInvoice.tsx
+++ b/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/UpcomingInvoices/UpcomingInvoice.tsx
@@ -1,9 +1,9 @@
-import { toZonedTime } from 'date-fns-tz';
+import { format } from 'date-fns-tz';
+import { UTCDate } from '@date-fns/utc';
 import { addDays } from 'date-fns/addDays';
 import { observer } from 'mobx-react-lite';
 
 import { Contract } from '@graphql/types';
-import { DateTimeUtils } from '@utils/date';
 import { useStore } from '@shared/hooks/useStore';
 import { formatCurrency } from '@utils/getFormattedCurrencyNumber';
 import { useTimelineEventPreviewMethodsContext } from '@organization/components/Timeline/shared/TimelineEventPreview/context/TimelineEventPreviewContext';
@@ -42,17 +42,11 @@ export const UpcomingInvoice = observer(
     );
     const autoRenewal = contract?.autoRenew;
 
-    const invoicePeriodStart = toZonedTime(
-      invoice?.invoicePeriodStart,
-      'UTC',
-    ).toUTCString();
-    const invoicePeriodEnd = toZonedTime(
-      invoice?.invoicePeriodEnd,
-      'UTC',
-    ).toUTCString();
+    const invoicePeriodStart = new UTCDate(invoice?.invoicePeriodStart);
+    const invoicePeriodEnd = new UTCDate(invoice?.invoicePeriodEnd);
 
     const nextInvoiceDate = invoice?.postpaid
-      ? toZonedTime(addDays(new Date(invoicePeriodEnd), 1), 'UTC').toUTCString()
+      ? new UTCDate(addDays(invoicePeriodEnd, 1))
       : invoicePeriodStart;
 
     return (
@@ -68,21 +62,9 @@ export const UpcomingInvoice = observer(
         </div>
         <div className='whitespace-nowrap text-grayModern-500 underline'>
           {formatCurrency(invoice.amountDue, 2, invoice?.currency)} on{' '}
-          {DateTimeUtils.format(
-            nextInvoiceDate,
-            DateTimeUtils.defaultFormatShortString,
-          )}{' '}
-          (
-          {DateTimeUtils.format(
-            invoicePeriodStart,
-            DateTimeUtils.dateDayAndMonth,
-          )}{' '}
-          -{' '}
-          {DateTimeUtils.format(
-            invoicePeriodEnd,
-            DateTimeUtils.defaultFormatShortString,
-          )}
-          )
+          {format(nextInvoiceDate, 'd MMM ’yy')} (
+          {format(invoicePeriodStart, 'd MMM')} -{' '}
+          {format(invoicePeriodEnd, 'd MMM ’yy')})
         </div>
       </div>
     );

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,3 +1,4 @@
+import { UTCDate } from '@date-fns/utc';
 import { format, toZonedTime } from 'date-fns-tz';
 import { differenceInDays } from 'date-fns/differenceInDays';
 import { differenceInHours } from 'date-fns/differenceInHours';
@@ -39,10 +40,13 @@ export type ReturnDifference =
   | [1, 'year', string, 'months']
   | [number, 'years', string, 'months'];
 
+/**
+ * @deprecated Use date-fns imports directly instead
+ */
 export class DateTimeUtils {
   private static defaultFormatString = "EEE dd MMM - HH'h' mm zzz"; // Output: "Wed 08 Mar - 14h30CET"
   public static dateWithFullMonth = 'd MMMM yyyy'; // Output: "1 August 2024"
-  public static defaultFormatShortString = 'dd MMM ’yy'; // Output: "1 Aug '24"
+  public static defaultFormatShortString = 'd MMM ’yy'; // Output: "1 Aug '24"
   public static dateWithHour = 'd MMM yyyy • HH:mm'; // Output: "19 Jun 2023 • 14:34"
   public static date = 'd MMM yyyy'; // Output: "19 Jun 2023"
   public static dateWithAbreviatedMonth = 'd MMM yyyy'; // Output: "1 Aug 2024"
@@ -63,8 +67,15 @@ export class DateTimeUtils {
     return new Date(new Date(date).toUTCString());
   }
 
-  public static format(date: string | number, formatString?: string): string {
+  public static format(
+    date: string | number | Date | UTCDate,
+    formatString?: string,
+  ): string {
     const formatStr = formatString || this.defaultFormatString;
+
+    if (date instanceof UTCDate || date instanceof Date) {
+      return date ? format(date, formatStr) : '';
+    }
 
     return date ? format(this.getDate(date), formatStr) : '';
   }


### PR DESCRIPTION
- Replace toZonedTime with UTCDate for more direct date manipulation
- Update date formatting to use date-fns format directly
- Mark DateTimeUtils as deprecated in favor of direct date-fns imports
- Simplify date formatting in UpcomingInvoice component