### PR TITLE
patch:fix empty state mailboxes

### DIFF
--- a/src/routes/settings/src/components/Tabs/panels/Personal/Mailboxes/Mailboxes.tsx
+++ b/src/routes/settings/src/components/Tabs/panels/Personal/Mailboxes/Mailboxes.tsx
@@ -25,7 +25,7 @@ export const Mailboxes = observer(() => {
   const campaign = searchParams.get('campaign');
   const campaignParam = campaign ? `&campaign=${campaign}` : '';
 
-  const hasMailstack =
+  const _hasMailstack =
     store.mailboxes
       ?.toArray()
       .filter((v) => v.value.provider === MailboxProvider.Mailstack).length > 0;
@@ -81,7 +81,7 @@ export const Mailboxes = observer(() => {
     );
   }
 
-  if (showOutbound && hasMailstack) {
+  if (showOutbound) {
     return <EmptyMailstack onUpdate={goBuy} />;
   }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes display logic for `EmptyMailstack` in `Mailboxes.tsx` by removing `hasMailstack` condition, ensuring it shows when `showOutbound` is true.
> 
>   - **Behavior**:
>     - Fixes display logic for `EmptyMailstack` in `Mailboxes.tsx` by removing `hasMailstack` condition.
>     - `EmptyMailstack` now shows when `showOutbound` is true, regardless of Mailstack mailboxes presence.
>   - **Variables**:
>     - Renames `hasMailstack` to `_hasMailstack` in `Mailboxes.tsx` to indicate unused variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for b7864d6ef37ecb808c71698f062b8a7ea653bdae. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->