### PR TITLE
patch:fix wired scroll on emptyState for tables

### DIFF
--- a/src/routes/finder/page.tsx
+++ b/src/routes/finder/page.tsx
@@ -50,7 +50,7 @@ export const FinderPage = observer(() => {
           <Search />
         </div>
         <div className='flex'>
-          <div className=' w-full overflow-auto'>
+          <div className=' w-full overflow-auto h-full'>
             <FiltersContainer />
             <FinderTable />
           </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix scrolling issue on empty table state by setting full height on container div in `page.tsx`.
> 
>   - **CSS Adjustment**:
>     - In `page.tsx`, set `h-full` on the `div` containing `FiltersContainer` and `FinderTable` to ensure full height for proper scrolling behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 3cf02ff1807e7184a73aedb525984a10077585fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->