### PR TITLE
Fix slack pr

### DIFF
--- a/.github/workflows/pr-notifications.yml
+++ b/.github/workflows/pr-notifications.yml
@@ -2,13 +2,14 @@ name: PR Notifications
                 
 on:
   pull_request:
-    types: [opened, synchronize, review_submitted, closed]
+    types: [opened, synchronize, review_submitted, closed, ready_for_review]
   pull_request_review:
     types: [submitted, dismissed]
+  issue_comment:
+    types: [created]
 
 jobs:
   notify:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Handle PR Events
@@ -128,21 +129,13 @@ jobs:
                 // Process different actions
                 switch(action) {
                   case 'opened':
-                    // Just created the message, no reactions yet
-                    await addReaction(messageInfo, 'eyes');
+                    // No reactions when PR is first opened
                     break;
                     
-                  case 'synchronize':
-                    // PR was updated with new commits, remove approval if exists
-                    if (currentReactions.includes(REACTIONS.APPROVED)) {
-                      await removeReaction(messageInfo, REACTIONS.APPROVED);
-                    }
-                    break;
-                    
-                  case 'approved':
-                    // PR was approved, add approval reaction
-                    if (!currentReactions.includes(REACTIONS.APPROVED)) {
-                      await addReaction(messageInfo, REACTIONS.APPROVED);
+                  case 'commented':
+                    // Add eyes reaction when PR gets a comment
+                    if (!currentReactions.includes('eyes')) {
+                      await addReaction(messageInfo, 'eyes');
                     }
                     break;
                     
@@ -156,6 +149,9 @@ jobs:
                       }
                       if (currentReactions.includes(REACTIONS.CLOSED)) {
                         await removeReaction(messageInfo, REACTIONS.CLOSED);
+                      }
+                      if (currentReactions.includes('eyes')) {
+                        await removeReaction(messageInfo, 'eyes');
                       }
                     }
                     break;
@@ -230,7 +226,8 @@ jobs:
             
             // Determine the action based on the event
             if (eventName === 'pull_request') {
-              if (payload.action === 'opened') {
+              if (payload.action === 'opened' || payload.action === 'ready_for_review') {
+                // Handle both new PRs and PRs moved from draft to ready
                 action = 'opened';
               } else if (payload.action === 'synchronize') {
                 action = 'synchronize';
@@ -244,6 +241,9 @@ jobs:
                 action = 'approved';
                 existingMessage = await findPrMessage();
               }
+            } else if (eventName === 'issue_comment' && payload.issue.pull_request) {
+              action = 'commented';
+              existingMessage = await findPrMessage();
             }
             
             // Handle the action

--- a/.github/workflows/pr-notifications.yml
+++ b/.github/workflows/pr-notifications.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   notify:
+    # Only run for non-draft PRs OR when a PR becomes ready for review
+    if: github.event.pull_request.draft == false || github.event.action == 'ready_for_review'
     runs-on: ubuntu-latest
     steps:
       - name: Handle PR Events

--- a/.github/workflows/pr-notifications.yml
+++ b/.github/workflows/pr-notifications.yml
@@ -1,5 +1,5 @@
 name: PR Notifications
-                
+
 on:
   pull_request:
     types: [opened, synchronize, review_submitted, closed, ready_for_review]
@@ -72,7 +72,7 @@ jobs:
                 });
                 const userData = await userResponse.json();
                 const displayName = userData.name || pr.user.login;
-                const message = `\`${context.repo.owner}/${context.repo.repo}\` <${pr.html_url}|${pr.title}>`;
+                const message = `\`${context.repo.repo}\` <${pr.html_url}|${pr.title}>`;
                 
                 const response = await fetch('https://slack.com/api/chat.postMessage', {
                   method: 'POST',


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance Slack notifications by adding new event types and modifying reactions for comments and PR status changes in `pr-notifications.yml`.
> 
>   - **Events**:
>     - Add `ready_for_review` to `pull_request` events in `pr-notifications.yml`.
>     - Add `created` to `issue_comment` events.
>   - **Conditions**:
>     - Modify `if` condition to run for non-draft PRs or when PR becomes ready for review.
>   - **Reactions**:
>     - Remove initial reactions for `opened` PRs.
>     - Add `eyes` reaction for `commented` PRs.
>     - Remove `eyes` reaction when PR is merged or closed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 354bc0ebde13d08c4d06734ec64ac3c369bb865e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->