### PR TITLE
patch:Update JWT expiration to 7 days and enhance session management …

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -397,7 +397,7 @@ async function createServer() {
         },
         process.env.JWT_SECRET,
         {
-          expiresIn: '30d',
+          expiresIn: '7 days',
         },
       );
 
@@ -523,6 +523,7 @@ async function createServer() {
           idToken: tokens.id_token,
         },
       });
+
       const loginResponse = await loginResponsePromise.json();
 
       const integrations_token = createIntegrationAppToken(
@@ -549,7 +550,7 @@ async function createServer() {
         },
         process.env.JWT_SECRET,
         {
-          expiresIn: '30d',
+          expiresIn: '7 days',
         },
       );
 
@@ -657,7 +658,7 @@ async function createServer() {
         },
         process.env.JWT_SECRET,
         {
-          expiresIn: '30d',
+          expiresIn: '7 days',
         },
       );
 

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -397,7 +397,7 @@ async function createServer() {
         },
         process.env.JWT_SECRET,
         {
-          expiresIn: '7 days',
+          expiresIn: '7d',
         },
       );
 
@@ -550,7 +550,7 @@ async function createServer() {
         },
         process.env.JWT_SECRET,
         {
-          expiresIn: '7 days',
+          expiresIn: '7d',
         },
       );
 
@@ -658,7 +658,7 @@ async function createServer() {
         },
         process.env.JWT_SECRET,
         {
-          expiresIn: '7 days',
+          expiresIn: '7d',
         },
       );
 

--- a/src/store/Session/Session.store.ts
+++ b/src/store/Session/Session.store.ts
@@ -115,18 +115,7 @@ export class SessionStore {
 
     if (this.isAuthenticated) {
       // Refresh session data
-
-      if (
-        !!this.value.exp &&
-        this.value.exp > Date.now() / 1000 + 7 * 24 * 60 * 60
-      ) {
-        this.clearSession();
-        window.location.href = '/auth/signin';
-
-        return;
-      } else {
-        await this.fetchSession();
-      }
+      await this.fetchSession();
 
       return;
     }

--- a/src/store/Session/Session.store.ts
+++ b/src/store/Session/Session.store.ts
@@ -115,7 +115,18 @@ export class SessionStore {
 
     if (this.isAuthenticated) {
       // Refresh session data
-      await this.fetchSession();
+
+      if (
+        !!this.value.exp &&
+        this.value.exp > Date.now() / 1000 + 7 * 24 * 60 * 60
+      ) {
+        this.clearSession();
+        window.location.href = '/auth/signin';
+
+        return;
+      } else {
+        await this.fetchSession();
+      }
 
       return;
     }

--- a/src/store/window-manager.ts
+++ b/src/store/window-manager.ts
@@ -24,10 +24,20 @@ export class WindowManager {
     );
 
     window.addEventListener('focus', () => {
-      // todo call graphql
-      // query version {
-      //   version
-      // }
+      if (this.root.session.value.exp) {
+        const expirationDate = new Date(this.root.session.value.exp * 1000);
+        const currentDate = new Date();
+        const differenceInDays =
+          (expirationDate.getTime() - currentDate.getTime()) /
+          (1000 * 3600 * 24);
+
+        if (differenceInDays > 7) {
+          this.root.session.clearSession();
+          setTimeout(() => {
+            window.location.href = '/auth/signin';
+          }, 1000);
+        }
+      }
     });
     window.addEventListener('blur', () => {
       this.persistLastActiveAt();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update JWT expiration to 7 days and enhance session management by redirecting expired sessions to sign-in.
> 
>   - **JWT Expiration**:
>     - Update JWT expiration from 30 days to 7 days in `createServer()` in `middleware/index.js`.
>     - Affects session tokens in Google and Azure AD authentication flows.
>   - **Session Management**:
>     - In `WindowManager` in `window-manager.ts`, add logic to check session expiration on window focus.
>     - Redirect to `/auth/signin` if session is expired (more than 7 days).
>   - **Misc**:
>     - Minor formatting change in `middleware/index.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for eedb0c747f7365837131aa14fb0a1b5b199959c7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->