### PR TITLE
patch: remove some validations for product line item

### DIFF
--- a/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/Products/components/ProductItem/ProductItemEdit.tsx
+++ b/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/Products/components/ProductItem/ProductItemEdit.tsx
@@ -122,43 +122,25 @@ export const ProductItemEdit = observer(
         );
       };
 
-      const checkIfBeforeToday = (date: Date) => {
-        if (isDraft || type === 'one-time') return null;
+      // const checkIfBeforeToday = (date: Date) => {
+      //   if (isDraft || type === 'one-time') return null;
 
-        if (allServices?.length === 1) {
-          return DateTimeUtils.isBefore(date.toString(), new Date().toString());
-        }
+      //   if (allServices?.length === 1) {
+      //     return DateTimeUtils.isBefore(date.toString(), new Date().toString());
+      //   }
 
-        return false;
-      };
+      //   return false;
+      // };
 
       const existingServiceStarted = checkExistingServiceStarted(utcDate);
-      const isTodayOrBefore = checkIfBeforeToday(utcDate);
+      // const isTodayOrBefore = checkIfBeforeToday(utcDate);
       const currentService = findCurrentService();
       const isBeforeCurrentService = checkIfBeforeCurrentService(
         utcDate,
         currentService,
       );
 
-      if (isTodayOrBefore) {
-        toastError(
-          `Select a service start date that is in the future`,
-          `${service?.tempValue?.metadata?.id}-service-started-date-update-error`,
-        );
-
-        return;
-      }
-
-      if (isBeforeCurrentService) {
-        toastError(
-          `Modifications must be effective after the current service`,
-          `${service?.tempValue?.metadata?.id}-service-started-date-update-error`,
-        );
-
-        return;
-      }
-
-      if (isBeforeCurrentService) {
+      if (isBeforeCurrentService && type !== 'one-time') {
         toastError(
           `Modifications must be effective after the current service`,
           `${service?.tempValue?.metadata?.id}-service-started-date-update-error`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed certain date validations in `ProductItemEdit.tsx`, simplifying checks for 'one-time' services.
> 
>   - **Behavior**:
>     - Removed `checkIfBeforeToday` function and its usage in `ProductItemEdit.tsx`.
>     - Simplified date validation by removing checks for dates before today, focusing on `isBeforeCurrentService`.
>     - Adjusted `isBeforeCurrentService` check to exclude 'one-time' services.
>   - **Error Handling**:
>     - Removed error toast for selecting a service start date in the past.
>     - Retained error toast for modifications before the current service, except for 'one-time' services.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 8505ca2c465822e05e1f66819f50c249ff84e5d7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->