### PR TITLE
chore: Add PhoenixMap and Store classes with tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "fuse.js": "^7.0.0",
         "graphql": "^16.8.1",
         "graphql-request": "^6.1.0",
+        "hash-it": "^6.0.0",
         "highlight.run": "^8.12.2",
         "html-react-parser": "^5.1.10",
         "html-to-text": "^9.0.5",
@@ -12852,6 +12853,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/hash-it": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hash-it/-/hash-it-6.0.0.tgz",
+      "integrity": "sha512-KHzmSFx1KwyMPw0kXeeUD752q/Kfbzhy6dAZrjXV9kAIXGqzGvv8vhkUqj+2MGZldTo0IBpw6v7iWE7uxsvH0w=="
     },
     "node_modules/hasown": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "fuse.js": "^7.0.0",
     "graphql": "^16.8.1",
     "graphql-request": "^6.1.0",
+    "hash-it": "^6.0.0",
     "highlight.run": "^8.12.2",
     "html-react-parser": "^5.1.10",
     "html-to-text": "^9.0.5",

--- a/src/lib/phoenix-map.test.ts
+++ b/src/lib/phoenix-map.test.ts
@@ -1,0 +1,446 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Channel } from 'phoenix';
+
+import { autorun } from 'mobx';
+import { it, vi, Mock, expect, describe, beforeEach } from 'vitest';
+
+import { PhoenixMap } from './phoenix-map';
+
+describe('PhoenixMap sync', () => {
+  let channelMock: Channel;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  let handlers: Record<string, Function>;
+
+  beforeEach(() => {
+    handlers = {};
+
+    channelMock = {
+      push: vi.fn(),
+      on: vi.fn((event, callback) => {
+        handlers[event] = callback;
+
+        return Math.floor(Math.random() * 100); // fake ref
+      }),
+      off: vi.fn(),
+      topic: 'test',
+      state: 'joined',
+      join: vi.fn(),
+      leave: vi.fn(),
+      onClose: vi.fn(),
+      onError: vi.fn(),
+      onMessage: vi.fn(),
+    } as unknown as Channel;
+  });
+
+  it('should create an instance of PhoenixMap', () => {
+    const map = new PhoenixMap(channelMock);
+
+    expect(map).toBeInstanceOf(PhoenixMap);
+  });
+
+  it('should call channel.push() on set()', () => {
+    const map = new PhoenixMap(channelMock);
+
+    map.set('foo', 'bar');
+
+    expect(channelMock.push).toHaveBeenCalledWith(
+      'store:set',
+      expect.objectContaining({
+        type: 'store:set',
+        key: 'foo',
+        value: 'bar',
+        source: expect.any(String),
+      }),
+    );
+    expect(map.get('foo')).toBe('bar');
+  });
+
+  it('should call channel.push() on delete()', () => {
+    const map = new PhoenixMap(channelMock);
+
+    map.set('foo', 'bar'); // so it exists
+    map.delete('foo');
+
+    expect(channelMock.push).toHaveBeenCalledWith(
+      'store:delete',
+      expect.objectContaining({
+        type: 'store:delete',
+        key: 'foo',
+        source: expect.any(String),
+      }),
+    );
+    expect(map.has('foo')).toBe(false);
+  });
+
+  it('should call channel.push() on clear()', () => {
+    const map = new PhoenixMap(channelMock);
+
+    map.set('foo', 'bar');
+    map.set('baz', 'qux');
+
+    map.clear();
+
+    expect(channelMock.push).toHaveBeenCalledWith(
+      'store:clear',
+      expect.objectContaining({
+        type: 'store:clear',
+        source: expect.any(String),
+      }),
+    );
+    expect(map.size).toBe(0);
+  });
+
+  it('should apply external set messages', () => {
+    const map = new PhoenixMap(channelMock);
+
+    handlers['store:set']?.({
+      type: 'store:set',
+      key: 'a',
+      value: 42,
+      source: 'other-client-id',
+    });
+
+    expect(map.get('a')).toBe(42);
+  });
+
+  it('should ignore own set messages', () => {
+    const map = new PhoenixMap(channelMock);
+    const clientId = (map as any).clientId;
+
+    handlers['store:set']?.({
+      type: 'store:set',
+      key: 'a',
+      value: 999,
+      source: clientId,
+    });
+
+    expect(map.get('a')).toBe(undefined);
+  });
+
+  it('should apply external delete messages', () => {
+    const map = new PhoenixMap(channelMock);
+
+    map.set('x', 'y');
+
+    handlers['store:delete']?.({
+      type: 'store:delete',
+      key: 'x',
+      source: 'someone-else',
+    });
+
+    expect(map.has('x')).toBe(false);
+  });
+
+  it('should apply external clear messages', () => {
+    const map = new PhoenixMap(channelMock);
+
+    map.set('a', 1);
+    map.set('b', 2);
+
+    handlers['store:clear']?.({
+      type: 'store:clear',
+      source: 'someone-else',
+    });
+
+    expect(map.size).toBe(0);
+  });
+
+  it('should call channel.off() with correct refs on destroy()', () => {
+    const map = new PhoenixMap(channelMock);
+
+    // Each on() returns a ref (number), we need to remember those for matching
+    const setRef = (map as any).handleRefs['store:set'];
+    const delRef = (map as any).handleRefs['store:delete'];
+    const clrRef = (map as any).handleRefs['store:clear'];
+
+    map.destroy();
+
+    expect(channelMock.off).toHaveBeenCalledWith('store:set', setRef);
+    expect(channelMock.off).toHaveBeenCalledWith('store:delete', delRef);
+    expect(channelMock.off).toHaveBeenCalledWith('store:clear', clrRef);
+  });
+
+  it('should fetch and update entity on store:invalidate event', async () => {
+    const fetchedOrg = { id: 'org-123', name: 'Acme Inc' };
+
+    const fetchFn = vi.fn().mockResolvedValue(fetchedOrg);
+
+    const map = new PhoenixMap(channelMock, {
+      fetchOnInvalidate: fetchFn,
+    });
+
+    await handlers['store:invalidate']({
+      type: 'store:invalidate',
+      key: 'org-123',
+      source: 'some-other-client',
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith('org-123');
+    expect(map.get('org-123')).toEqual(fetchedOrg);
+  });
+
+  it('should ignore self-originated store:invalidate event', async () => {
+    const fetchFn = vi.fn();
+
+    const map = new PhoenixMap(channelMock, {
+      fetchOnInvalidate: fetchFn,
+    });
+
+    const clientId = map.getClientId();
+
+    await handlers['store:invalidate']({
+      type: 'store:invalidate',
+      key: 'org-123',
+      source: clientId,
+    });
+
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('should suppress sync when suspendSync is used', () => {
+    const map = new PhoenixMap<string, Entity>(channelMock, {
+      versionBy: 'updatedAt',
+    });
+
+    map.suspendSync(() => {
+      map.set('org1', { id: 'org1', name: 'silent1', updatedAt: 1 });
+      map.set('org2', { id: 'org2', name: 'silent2', updatedAt: 2 });
+      map.delete('org1');
+      map.clear();
+    });
+
+    const pushCalls = (channelMock.push as Mock).mock.calls.map(
+      ([event]) => event,
+    );
+
+    expect(pushCalls).not.toContain('store:set');
+    expect(pushCalls).not.toContain('store:delete');
+    expect(pushCalls).not.toContain('store:clear');
+  });
+
+  it('should still emit MobX reactions inside suspendSync', () => {
+    const map = new PhoenixMap<string, Entity>(channelMock, {
+      versionBy: 'updatedAt',
+    });
+    const seen: string[] = [];
+
+    autorun(() => {
+      seen.length = 0;
+
+      for (const entry of map.entries()) {
+        seen.push(entry[0]);
+      }
+    });
+
+    map.suspendSync(() => {
+      map.set('orgA', { id: 'orgA', name: 'Alpha', updatedAt: 1 });
+      map.set('orgB', { id: 'orgB', name: 'Beta', updatedAt: 2 });
+    });
+
+    expect(seen).toContain('orgA');
+    expect(seen).toContain('orgB');
+  });
+});
+
+interface Entity {
+  id: string;
+  name: string;
+  updatedAt: number;
+}
+
+describe('PhoenixMap versioning', () => {
+  let channelMock: Channel;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  let handlers: Record<string, Function>;
+  let map: PhoenixMap<string, Entity>;
+
+  beforeEach(() => {
+    handlers = {};
+
+    channelMock = {
+      push: vi.fn(),
+      on: vi.fn((event, cb) => {
+        handlers[event] = cb;
+
+        return Math.random();
+      }),
+      off: vi.fn(),
+      join: vi.fn(),
+      leave: vi.fn(),
+      onClose: vi.fn(),
+      onError: vi.fn(),
+      onMessage: vi.fn(),
+      state: 'joined',
+      topic: 'test',
+    } as unknown as Channel;
+
+    map = new PhoenixMap(channelMock, {
+      versionBy: 'updatedAt',
+    });
+  });
+
+  it('should accept versioned values and overwrite if newer', () => {
+    map.set('org', { id: 'org', name: 'v1', updatedAt: 1 });
+    map.set('org', { id: 'org', name: 'v2', updatedAt: 2 });
+
+    expect(map.get('org')?.name).toBe('v2');
+  });
+
+  it('should ignore updates with same or older version', () => {
+    map.set('org', { id: 'org', name: 'v5', updatedAt: 5 });
+    map.set('org', { id: 'org', name: 'v3', updatedAt: 3 });
+
+    expect(map.get('org')?.name).toBe('v5');
+  });
+
+  it('should treat missing versionBy as no versioning', () => {
+    const plainMap = new PhoenixMap(channelMock);
+
+    plainMap.set('org', { id: 'org', name: 'first', updatedAt: 10 });
+    plainMap.set('org', { id: 'org', name: 'second', updatedAt: 5 });
+
+    expect(plainMap.get('org')?.name).toBe('second');
+  });
+
+  it('should handle store:set with newer version remotely', () => {
+    map.set('org', { id: 'org', name: 'v1', updatedAt: 1 });
+
+    handlers['store:set']?.({
+      type: 'store:set',
+      key: 'org',
+      value: { id: 'org', name: 'v3', updatedAt: 3 },
+      source: 'remote',
+    });
+
+    expect(map.get('org')?.name).toBe('v3');
+  });
+
+  it('should ignore store:set with older remote version', () => {
+    map.set('org', { id: 'org', name: 'latest', updatedAt: 10 });
+
+    handlers['store:set']?.({
+      type: 'store:set',
+      key: 'org',
+      value: { id: 'org', name: 'old', updatedAt: 5 },
+      source: 'remote',
+    });
+
+    expect(map.get('org')?.name).toBe('latest');
+  });
+
+  it('should use fetchOnInvalidate only if not already pending', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ id: 'org', name: 'remote', updatedAt: 2 });
+
+    map = new PhoenixMap(channelMock, {
+      versionBy: 'updatedAt',
+      fetchOnInvalidate: fetchMock,
+    });
+
+    handlers['store:invalidate']?.({
+      key: 'org',
+      source: 'other',
+      type: 'store:invalidate',
+    });
+    handlers['store:invalidate']?.({
+      key: 'org',
+      source: 'other',
+      type: 'store:invalidate',
+    });
+
+    await Promise.resolve(); // wait for promise microtasks
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should update with fetch result if newer', async () => {
+    map.set('org', { id: 'org', name: 'old', updatedAt: 1 });
+
+    map = new PhoenixMap(channelMock, {
+      versionBy: 'updatedAt',
+      fetchOnInvalidate: async () => ({
+        id: 'org',
+        name: 'fresh',
+        updatedAt: 5,
+      }),
+    });
+
+    handlers['store:invalidate']?.({
+      key: 'org',
+      source: 'another',
+      type: 'store:invalidate',
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(map.get('org')?.name).toBe('fresh');
+  });
+
+  it('should ignore fetch result if older', async () => {
+    map.set('org', { id: 'org', name: 'current', updatedAt: 10 });
+
+    map = new PhoenixMap(channelMock, {
+      versionBy: 'updatedAt',
+      fetchOnInvalidate: async () => ({
+        id: 'org',
+        name: 'stale',
+        updatedAt: 5,
+      }),
+      entries: [['org', { id: 'org', name: 'current', updatedAt: 10 }]],
+    });
+
+    handlers['store:invalidate']?.({
+      key: 'org',
+      source: 'server',
+      type: 'store:invalidate',
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(map.get('org')?.name).toBe('current');
+  });
+
+  it('should overwrite with older value when versionBy is not set', () => {
+    const plainMap = new PhoenixMap(channelMock);
+
+    plainMap.set('org', { id: 'org', name: 'first', updatedAt: 10 });
+    plainMap.set('org', { id: 'org', name: 'second', updatedAt: 5 });
+
+    expect(plainMap.get('org')?.name).toBe('second'); // overwritten despite lower updatedAt
+  });
+
+  it('should apply remote set with lower version when versionBy is not set', () => {
+    const plainMap = new PhoenixMap(channelMock);
+
+    plainMap.set('org', { id: 'org', name: 'local', updatedAt: 10 });
+
+    handlers['store:set']?.({
+      type: 'store:set',
+      key: 'org',
+      value: { id: 'org', name: 'remote-lower', updatedAt: 2 },
+      source: 'external-client',
+    });
+
+    expect(plainMap.get('org')?.name).toBe('remote-lower'); // allowed
+  });
+
+  it('should apply fetch result even if older when versionBy is not set', async () => {
+    const plainMap = new PhoenixMap(channelMock, {
+      fetchOnInvalidate: async () => ({
+        id: 'org',
+        name: 'fetched-old',
+        updatedAt: 2,
+      }),
+      entries: [['org', { id: 'org', name: 'bootstrapped', updatedAt: 99 }]],
+    });
+
+    handlers['store:invalidate']?.({
+      key: 'org',
+      source: 'server',
+      type: 'store:invalidate',
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(plainMap.get('org')?.name).toBe('fetched-old');
+  });
+});

--- a/src/lib/phoenix-map.ts
+++ b/src/lib/phoenix-map.ts
@@ -1,0 +1,233 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Channel } from 'phoenix';
+import { runInAction, ObservableMap } from 'mobx';
+
+type PhoenixStoreEvent =
+  | { key: any; value: any; source: string; type: 'store:set' }
+  | { key: any; source: string; type: 'store:delete' }
+  | { source: string; type: 'store:clear' }
+  | { key: any; source: string; type: 'store:invalidate' };
+
+export class PhoenixMap<K = any, V = any> extends ObservableMap<K, V> {
+  private channel: Channel;
+  private readonly clientId: string;
+  private readonly handleRefs = {
+    'store:set': 0,
+    'store:clear': 2,
+    'store:delete': 1,
+    'store:invalidate': 3,
+  };
+
+  private pendingFetches = new Map<K, Promise<void>>();
+  private isSyncSuspended = false;
+
+  constructor(
+    channel: Channel,
+    private options?: {
+      versionBy?: keyof V;
+      entries?: readonly (readonly [K, V])[];
+      fetchOnInvalidate?: (id: K) => Promise<V>;
+    },
+  ) {
+    super();
+    this.channel = channel;
+    this.clientId = crypto.randomUUID();
+
+    if (options?.entries) {
+      for (const [key, value] of options.entries) {
+        runInAction(() => {
+          super.set(key, value); // bypass sync
+        });
+      }
+    }
+
+    this.init();
+  }
+
+  suspendSync(fn: () => void) {
+    this.isSyncSuspended = true;
+
+    try {
+      fn();
+    } finally {
+      this.isSyncSuspended = false;
+    }
+  }
+
+  private getVersion(value: V): number | undefined {
+    const field = this.options?.versionBy;
+
+    return field && typeof value === 'object' && value !== null
+      ? (value[field] as unknown as number)
+      : undefined;
+  }
+
+  override set(key: K, value: V): this {
+    const version = this.getVersion(value);
+
+    if (version !== undefined) {
+      const current = this.get(key);
+      const currentVersion = current ? this.getVersion(current) ?? 0 : 0;
+
+      if (version > currentVersion) {
+        runInAction(() => {
+          super.set(key, value);
+        });
+      } else {
+        return this;
+      }
+    } else {
+      runInAction(() => {
+        super.set(key, value);
+      });
+    }
+
+    if (!this.isSyncSuspended) {
+      this.channel.push('store:set', {
+        type: 'store:set',
+        key,
+        value,
+        source: this.clientId,
+      });
+    }
+
+    return this;
+  }
+
+  override delete(key: K): boolean {
+    if (!this.isSyncSuspended) {
+      this.channel.push('store:delete', {
+        type: 'store:delete',
+        key,
+        source: this.clientId,
+      });
+    }
+
+    let res: boolean = true;
+
+    runInAction(() => {
+      res = super.delete(key);
+    });
+
+    return res;
+  }
+
+  override clear(): void {
+    if (!this.isSyncSuspended) {
+      this.channel.push('store:clear', {
+        type: 'store:clear',
+        source: this.clientId,
+      });
+    }
+
+    runInAction(() => {
+      super.clear();
+    });
+  }
+
+  private init() {
+    this.handleRefs['store:set'] = this.channel.on(
+      'store:set',
+      ({
+        key,
+        value,
+        source,
+      }: PhoenixStoreEvent & { value: V; type: 'store:set' }) => {
+        if (source === this.clientId) return;
+
+        const version = this.getVersion(value);
+
+        if (version !== undefined) {
+          const current = this.get(key);
+          const currentVersion = current ? this.getVersion(current) ?? 0 : 0;
+
+          if (version > currentVersion) {
+            runInAction(() => {
+              super.set(key, value);
+            });
+          }
+        } else {
+          runInAction(() => {
+            super.set(key, value);
+          });
+        }
+      },
+    );
+
+    this.handleRefs['store:delete'] = this.channel.on(
+      'store:delete',
+      ({ key, source }: PhoenixStoreEvent & { type: 'store:delete' }) => {
+        if (source !== this.clientId) {
+          runInAction(() => {
+            super.delete(key);
+          });
+        }
+      },
+    );
+
+    this.handleRefs['store:clear'] = this.channel.on(
+      'store:clear',
+      ({ source }: PhoenixStoreEvent & { type: 'store:clear' }) => {
+        if (source !== this.clientId) {
+          runInAction(() => {
+            super.clear();
+          });
+        }
+      },
+    );
+
+    if (this.options?.fetchOnInvalidate) {
+      this.handleRefs['store:invalidate'] = this.channel.on(
+        'store:invalidate',
+        async ({
+          key,
+          source,
+        }: PhoenixStoreEvent & { type: 'store:invalidate' }) => {
+          if (source === this.clientId) return;
+          if (this.pendingFetches.has(key)) return;
+
+          const fetchStartedAt = Date.now();
+
+          const fetchPromise = this.options!.fetchOnInvalidate!(key)
+            .then((fetched) => {
+              const version = this.getVersion(fetched);
+              const current = this.get(key);
+              const currentVersion = current
+                ? this.getVersion(current) ?? 0
+                : 0;
+
+              if (
+                (version !== undefined &&
+                  version > currentVersion &&
+                  fetchStartedAt > currentVersion) ||
+                version === undefined
+              ) {
+                runInAction(() => {
+                  super.set(key, fetched);
+                });
+              }
+            })
+            .finally(() => {
+              this.pendingFetches.delete(key);
+            });
+
+          this.pendingFetches.set(key, fetchPromise);
+        },
+      );
+    }
+  }
+
+  public getClientId() {
+    return this.clientId;
+  }
+
+  destroy() {
+    this.channel.off('store:set', this.handleRefs['store:set']);
+    this.channel.off('store:delete', this.handleRefs['store:delete']);
+    this.channel.off('store:clear', this.handleRefs['store:clear']);
+
+    if (this.handleRefs['store:invalidate']) {
+      this.channel.off('store:invalidate', this.handleRefs['store:invalidate']);
+    }
+  }
+}

--- a/src/lib/store-integration.test.ts
+++ b/src/lib/store-integration.test.ts
@@ -1,0 +1,276 @@
+/* eslint-disable @typescript-eslint/ban-types */
+import type { Channel } from 'phoenix';
+
+import { autorun, runInAction } from 'mobx';
+import { vi, it, Mock, expect, describe, beforeEach } from 'vitest';
+
+import { Store } from './store';
+import { PhoenixMap } from './phoenix-map';
+
+const createChannelMock = (handlers: Record<string, Function>) => {
+  return {
+    push: vi.fn(),
+    on: vi.fn((event, callback) => {
+      handlers[event] = callback;
+
+      return Math.floor(Math.random() * 100); // fake ref
+    }),
+    off: vi.fn(),
+    topic: 'test',
+    state: 'joined',
+    join: vi.fn(),
+    leave: vi.fn(),
+    onClose: vi.fn(),
+    onError: vi.fn(),
+    onMessage: vi.fn(),
+  } as unknown as Channel;
+};
+
+describe('Store - general integrations', () => {
+  let channelMock: Channel;
+  let handlers: Record<string, Function>;
+  let store: Store<object>;
+
+  beforeEach(() => {
+    handlers = {};
+
+    channelMock = createChannelMock(handlers);
+
+    store = new Store<Entity>({
+      cache: () => new PhoenixMap(channelMock),
+      mutator: runInAction,
+    });
+  });
+
+  it('should init', () => {
+    expect(store).toBeInstanceOf(Store);
+  });
+
+  it('should have PhoenixMap as cache instance', () => {
+    expect(store.cache).toBeInstanceOf(PhoenixMap);
+  });
+
+  it('should push to channel and store the value on add()', () => {
+    store.set('key1', { foo: 'baz' });
+
+    expect(channelMock.push).toHaveBeenCalledWith(
+      'store:set',
+      expect.objectContaining({
+        key: 'key1',
+        value: { foo: 'baz' },
+        type: 'store:set',
+        source: expect.any(String),
+      }),
+    );
+  });
+
+  it('should push to channel and delete the value on delete()', () => {
+    store.set('key2', { bar: 'baz' });
+    store.delete('key2');
+
+    expect(channelMock.push).toHaveBeenCalledWith(
+      'store:delete',
+      expect.objectContaining({
+        key: 'key2',
+        type: 'store:delete',
+        source: expect.any(String),
+      }),
+    );
+
+    expect(store.get('key2')).toBeUndefined();
+  });
+
+  it('should apply external store:set event', () => {
+    handlers['store:set']({
+      key: 'remoteKey',
+      value: { foo: 'boo' },
+      type: 'store:set',
+      source: 'another-client',
+    });
+
+    expect(store.get('remoteKey')).toStrictEqual({ foo: 'boo' });
+  });
+
+  it('should ignore self store:set event', () => {
+    store.set('localKey', { a: 'b' });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const clientId = (store.cache as any).clientId;
+
+    handlers['store:set']({
+      key: 'localKey',
+      value: { foo: 'baz' },
+      type: 'store:set',
+      source: clientId,
+    });
+
+    expect(store.get('localKey')).toStrictEqual({ a: 'b' });
+  });
+
+  it('should apply external store:delete event', () => {
+    store.set('toDelete', { a: 'c' });
+    handlers['store:delete']({
+      key: 'toDelete',
+      type: 'store:delete',
+      source: 'someone-else',
+    });
+
+    expect(store.get('toDelete')).toBeUndefined();
+  });
+
+  it('should apply external store:clear event', () => {
+    store.set('k1', { a: 'a' });
+    store.set('k2', { b: 'b' });
+
+    handlers['store:clear']({
+      type: 'store:clear',
+      source: 'someone-else',
+    });
+
+    expect(store.get('k1')).toBeUndefined();
+    expect(store.get('k2')).toBeUndefined();
+  });
+
+  it('should call channel.off() for all events on destroy()', () => {
+    const map = store.cache as PhoenixMap;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const refs = (map as any).handleRefs;
+
+    map.destroy();
+
+    expect(channelMock.off).toHaveBeenCalledWith(
+      'store:set',
+      refs['store:set'],
+    );
+    expect(channelMock.off).toHaveBeenCalledWith(
+      'store:delete',
+      refs['store:delete'],
+    );
+    expect(channelMock.off).toHaveBeenCalledWith(
+      'store:clear',
+      refs['store:clear'],
+    );
+  });
+
+  it('should not track deep mutations unless explicitly updated', () => {
+    const obj = { nested: 'value' };
+
+    store.set('deep', obj);
+
+    obj.nested = 'changed';
+
+    expect(store.get('deep')).toEqual({ nested: 'value' });
+  });
+
+  it('should react to observable changes via MobX', () => {
+    const observed: [string | number, object][] = [];
+
+    autorun(() => {
+      observed.length = 0;
+
+      for (const [key, value] of store.cache.entries()) {
+        observed.push([key, value]);
+      }
+    });
+
+    store.set('x', { a: 'b' });
+    expect(observed).toContainEqual(['x', { a: 'b' }]);
+  });
+
+  it.each([
+    ['id1', { foo: 'bar' }],
+    ['num', { a: 1 }],
+    ['obj', { key: 'value' }],
+  ])('should store and retrieve %p → %p', (key, value) => {
+    store.set(key, value);
+    expect(store.get(key)).toEqual(value);
+  });
+});
+
+interface Entity {
+  id: string;
+  value: unknown;
+  updatedAt: number;
+}
+
+describe('Store - invalidate integrations', () => {
+  let channelMock: Channel;
+  let handlers: Record<string, Function>;
+  let store: Store<Entity>;
+  let spy: Mock;
+
+  beforeEach(() => {
+    handlers = {};
+    channelMock = createChannelMock(handlers);
+    store = new Store<Entity>({
+      cache: () =>
+        new PhoenixMap(channelMock, {
+          fetchOnInvalidate: spy,
+          versionBy: 'updatedAt',
+        }),
+      mutator: runInAction,
+    });
+  });
+
+  it('should init', () => {
+    expect(store).toBeInstanceOf(Store);
+  });
+
+  it('should call fetchOnInvalidate when store:invalidate is received', async () => {
+    spy = vi.fn().mockResolvedValue({
+      id: 'org1',
+      value: 'updated',
+      updatedAt: Date.now(),
+    });
+
+    store = new Store<Entity>({
+      cache: () =>
+        new PhoenixMap(channelMock, {
+          fetchOnInvalidate: spy,
+          versionBy: 'updatedAt',
+        }),
+      mutator: runInAction,
+    });
+
+    handlers['store:invalidate']?.({
+      key: 'org1',
+      source: 'remote',
+      type: 'store:invalidate',
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(spy).toHaveBeenCalledWith('org1');
+  });
+
+  it('should update store entry if fetched version is newer', async () => {
+    const now = Date.now();
+
+    spy = vi.fn().mockResolvedValue({
+      id: 'org2',
+      value: 'new',
+      updatedAt: now - 500,
+    });
+
+    store = new Store<Entity>({
+      cache: () =>
+        new PhoenixMap(channelMock, {
+          fetchOnInvalidate: spy,
+          versionBy: 'updatedAt',
+        }),
+      mutator: runInAction,
+    });
+
+    store.set('org2', { id: 'org2', value: 'old', updatedAt: now - 1000 });
+
+    handlers['store:invalidate']?.({
+      key: 'org2',
+      source: 'remote',
+      type: 'store:invalidate',
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(store.get('org2')).toMatchObject({ value: 'new' });
+  });
+});

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -1,0 +1,90 @@
+import { it, expect, describe } from 'vitest';
+import { runInAction, ObservableMap } from 'mobx';
+
+import { Store } from './store';
+
+describe('Store class', () => {
+  describe('constructor', () => {
+    const store = new Store();
+
+    it('should create an instance of Store when `new` is called', () => {
+      expect(store).toBeInstanceOf(Store);
+    });
+
+    it('should have a cache property instance of Map', () => {
+      expect(store).toHaveProperty('cache');
+      expect(store.cache).instanceOf(Map);
+    });
+
+    it('should have an option to specify the internal cache constructor', () => {
+      const store = new Store({ cache: ObservableMap });
+
+      expect(store.cache).toBeInstanceOf(ObservableMap);
+    });
+
+    it('should have an option to specify the internal mutator', () => {
+      const store = new Store({ mutator: runInAction });
+
+      expect(store.mutator).toBe(runInAction);
+    });
+  });
+
+  describe('add entries', () => {
+    const store = new Store();
+
+    const value = { id: 'a', a: 1 };
+
+    store.set(value.id, value);
+
+    it('should have a method of adding new entries in cache', () => {
+      expect(store.cache.has(value.id)).toBe(true);
+    });
+    it('should maintain the same reference for value once added in cache', () => {
+      expect(store.cache.get(value.id)).toBe(value);
+    });
+
+    it('should overwrite an existing entry with a new value if the same key is provided', () => {
+      const newValue = { id: 'a', a: 1 };
+
+      store.set(newValue.id, newValue);
+
+      expect(store.cache.has(newValue.id)).toBe(true);
+      expect(store.cache.get(newValue.id)).not.toBe(value);
+    });
+  });
+  describe('get entries', () => {
+    const store = new Store();
+    const value = { id: 'a', a: 1 };
+
+    store.set(value.id, value);
+
+    it('should have a method of getting entries from cache', () => {
+      expect(store).toHaveProperty('get');
+      expect(store.get).toBeDefined();
+      expect(store.get(value.id)).toBe(value);
+    });
+    it('should return undefined if the entry does not exist', () => {
+      expect(store.get('random')).toBeUndefined();
+    });
+  });
+  describe('delete entries', () => {
+    const store = new Store();
+    const value = { id: 'a', a: 1 };
+
+    store.set(value.id, value);
+
+    expect(store.cache.has(value.id)).toBe(true);
+
+    it('should have a method of deleting entries from cache', () => {
+      expect(store).toHaveProperty('delete');
+      expect(store.delete).toBeDefined();
+    });
+    it('should return true if the entry was deleted', () => {
+      expect(store.delete(value.id)).toBe(true);
+      expect(store.cache.has(value.id)).toBe(false);
+    });
+    it('should return false if the entry does not exist', () => {
+      expect(store.delete('random')).toBe(false);
+    });
+  });
+});

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,55 @@
+import { CacheOption, normalizeCacheFactory } from './util';
+
+interface StoreOptions<T> {
+  cache?: CacheOption<T>;
+  mutator?: (fn: () => void) => unknown;
+}
+
+export class Store<T> {
+  public mutator?: (fn: () => void) => unknown;
+  public cache: Map<string | number, T> = new Map();
+
+  constructor(options?: StoreOptions<T>) {
+    if (options?.cache) {
+      const factory = normalizeCacheFactory(options.cache);
+
+      this.cache = factory();
+    } else {
+      this.cache = new Map();
+    }
+
+    this.mutator = options?.mutator;
+  }
+
+  private mutate(fn: () => unknown): unknown {
+    if (this.mutator) {
+      return this.mutator(fn);
+    } else {
+      return fn();
+    }
+  }
+
+  set(key: string | number, value: T) {
+    let res;
+
+    this.mutate(() => {
+      res = this.cache.set(key, value);
+    });
+
+    return res;
+  }
+
+  get(key: string | number) {
+    return this.cache.get(key);
+  }
+
+  delete(key: string | number) {
+    let res;
+
+    this.mutate(() => {
+      res = this.cache.delete(key);
+    });
+
+    return res;
+  }
+}

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,0 +1,48 @@
+type MobXAPI = {
+  ObservableMap: MapConstructor;
+  runInAction: (fn: () => void) => void;
+  isObservable: (value: unknown) => boolean;
+};
+
+let mobxApi: MobXAPI | null = null;
+
+export function tryLoadMobX(): MobXAPI | null {
+  if (mobxApi) return mobxApi;
+
+  try {
+    const mobx = require('mobx');
+
+    if (mobx.runInAction && mobx.isObservable) {
+      mobxApi = {
+        runInAction: mobx.runInAction,
+        isObservable: mobx.isObservable,
+        ObservableMap: mobx.ObservableMap,
+      };
+
+      return mobxApi;
+    }
+  } catch {
+    // mobx is not available
+  }
+
+  return null;
+}
+
+export type CacheConstructor<T> = new () => Map<string | number, T>;
+export type CacheFactory<T> = () => Map<string | number, T>;
+export type CacheOption<T> = CacheConstructor<T> | CacheFactory<T>;
+
+export function normalizeCacheFactory<T>(
+  input: CacheOption<T>,
+): CacheFactory<T> {
+  if (isConstructor(input)) {
+    return () => new input();
+  }
+
+  return input;
+}
+
+function isConstructor<T>(fn: unknown): fn is CacheConstructor<T> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return typeof fn === 'function' && !!(fn as any).prototype?.constructor;
+}

--- a/src/lib/view.test.ts
+++ b/src/lib/view.test.ts
@@ -1,0 +1,47 @@
+import { it, vi, expect, describe } from 'vitest';
+
+import { View, ViewRegistry } from './view';
+
+describe('View class', () => {
+  describe('constructor', () => {
+    const src = { a: 1 };
+    const run = vi.fn(() => []);
+    const view = new View(src, run);
+
+    it('calling `new` should output an instance of View', () => {
+      expect(view).toBeInstanceOf(View);
+      expect(view).toHaveProperty('hash');
+      expect(view).toHaveProperty('run');
+      expect(view).toHaveProperty('invalidate');
+    });
+    it('should register new entry in ViewRegistry', () => {
+      expect(ViewRegistry.has(view.hash)).toBe(true);
+    });
+    it('should call `run` callback once', () => {
+      expect(run).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('invalidate', () => {
+    const src = { a: 2 };
+    let value = 1;
+    const run = vi.fn(() => value);
+
+    const view = new View(src, run);
+    const hash = view.hash;
+
+    value = 2;
+    view.invalidate();
+
+    it('should execute `run` callback if called', () => {
+      expect(run).toHaveBeenCalledTimes(2);
+    });
+    it('should replace the stored value while maintaining the same hash', () => {
+      expect(view.hash).toBe(hash);
+      expect(view.value()).toBe(value);
+    });
+    it('should replace the ViewRegistry entry if `run` returns a different value', () => {
+      expect(ViewRegistry.get(hash)).toBe(value);
+    });
+  });
+});

--- a/src/lib/view.ts
+++ b/src/lib/view.ts
@@ -1,0 +1,49 @@
+import hashit from 'hash-it';
+
+export class ViewRegistry {
+  public entries: Map<number, unknown> = new Map();
+  private static instance: ViewRegistry;
+
+  constructor() {}
+
+  public static getInstance() {
+    if (!ViewRegistry.instance) {
+      ViewRegistry.instance = new ViewRegistry();
+    }
+
+    return ViewRegistry.instance;
+  }
+
+  public static has(hash: number) {
+    return ViewRegistry.getInstance().entries.has(hash);
+  }
+
+  public static get(hash: number) {
+    return ViewRegistry.getInstance().entries.get(hash);
+  }
+
+  public static register(hash: number, value: unknown) {
+    ViewRegistry.getInstance().entries.set(hash, value);
+  }
+}
+
+export class View {
+  public hash: number;
+  public run: (...args: unknown[]) => unknown;
+
+  constructor(src: object, run: (...args: unknown[]) => unknown) {
+    this.hash = hashit(src);
+    this.run = run;
+
+    if (ViewRegistry.has(this.hash)) return;
+    ViewRegistry.register(this.hash, run());
+  }
+
+  value() {
+    return ViewRegistry.get(this.hash);
+  }
+
+  invalidate() {
+    ViewRegistry.register(this.hash, this.run());
+  }
+}

--- a/src/routes/src/components/CommandMenu/commands/agent/RenameAgent.tsx
+++ b/src/routes/src/components/CommandMenu/commands/agent/RenameAgent.tsx
@@ -30,10 +30,9 @@ export const RenameAgent = observer(() => {
         onValueChange={(value) => usecase.setInputValue(value)}
       />
       <Command.List>
-        <CommandItem
-          onSelect={usecase.execute}
-          leftAccessory={<Edit03 />}
-        >{`Rename agent to "${usecase.inputValue}"`}</CommandItem>
+        <CommandItem onSelect={usecase.execute} leftAccessory={<Edit03 />}>
+          <span className='truncate'>{`Rename agent to "${usecase.inputValue}"`}</span>
+        </CommandItem>
       </Command.List>
     </Command>
   );

--- a/src/routes/src/components/CommandMenu/commands/task/RenameTask.tsx
+++ b/src/routes/src/components/CommandMenu/commands/task/RenameTask.tsx
@@ -45,7 +45,9 @@ export const RenameTask = observer(() => {
         <CommandItem
           leftAccessory={<Edit03 />}
           onSelect={() => handleChangeName()}
-        >{`Rename task to "${task?.value.subject}"`}</CommandItem>
+        >
+          <span className='truncate'>{`Rename task to "${task?.value.subject}"`}</span>
+        </CommandItem>
       </Command.List>
     </Command>
   );

--- a/src/styles/cmdk.scss
+++ b/src/styles/cmdk.scss
@@ -7,7 +7,7 @@
 }
 
 [cmdk-list] {
-  @apply overflow-y-auto overscroll-contain max-h-[264px];
+  @apply overflow-y-auto overscroll-contain max-h-[264px] relative;
 
   &:has([cmdk-item]) {
     @apply p-2.5;

--- a/src/ui/overlay/CommandMenu/CommandMenu.tsx
+++ b/src/ui/overlay/CommandMenu/CommandMenu.tsx
@@ -7,8 +7,8 @@ import { IconButton } from '@ui/form/IconButton';
 import { XClose } from '@ui/media/icons/XClose.tsx';
 import { Button } from '@ui/form/Button/Button.tsx';
 import { Tag, TagLabel } from '@ui/presentation/Tag/Tag';
+import { isUserPlatformMac } from '@utils/getUserPlatform';
 import { ChevronRight } from '@ui/media/icons/ChevronRight';
-import { isUserPlatformMac } from '@utils/getUserPlatform.ts';
 import { Command as CommandIcon } from '@ui/media/icons/Command';
 
 interface CommandInputProps
@@ -118,9 +118,7 @@ export const CommandItem = forwardRef<HTMLDivElement, CommandItemProps>(
         {...props}
       >
         {leftAccessory && <span className='inline-flex'>{leftAccessory}</span>}
-        <span className='overflow-hidden truncate max-w-[430px] text-ellipsis'>
-          {children}
-        </span>
+        {children}
         {rightAccessory && (
           <div className='flex gap-1 items-center ml-auto'>
             {rightAccessory}


### PR DESCRIPTION
- Added `PhoenixMap` class for synchronized map-like data structure
- Added `Store` class for managing cached data with optional MobX integration
- Implemented tests for `PhoenixMap` and `Store` classes
- Integrated `hash-it` library for hashing objects
- Updated `CommandMenu` components to truncate long text in command items