### PR TITLE
patch: fix build trigger on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,12 @@ name: frontera
 on:
   push:
     branches: ['main']
-    tags: ['v*'] # release.yaml is manually creating a release tag
   pull_request:
     branches: ['main']
   release:
     types: [created, edited]
+  create:
+    tags: ['v*']
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix build trigger for release by adding `create` event with `tags: ['v*']` in `build.yml`.
> 
>   - **Workflow Trigger**:
>     - Added `create` event with `tags: ['v*']` in `.github/workflows/build.yml` to trigger builds on new tag creation matching `v*` pattern.
>     - Removed `tags: ['v*']` from `push` event to avoid redundancy.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 8562c7db5a8db10b02323077144666a1688f7713. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->