### PR TITLE
patch: fix build trigger on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
         with:
           tag_name: ${{ steps.generate_version.outputs.next_version }}
           generate_release_notes: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TRIGGER_FRONTERA_BUILD_TOKEN }}
 
       # Save outputs for the deploy workflow
       - name: Save workflow outputs


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update token in `release.yml` for `Create Release` step to use `${{ secrets.TRIGGER_FRONTERA_BUILD_TOKEN }}`.
> 
>   - **Authentication**:
>     - Update token in `release.yml` from `${{ secrets.GITHUB_TOKEN }}` to `${{ secrets.TRIGGER_FRONTERA_BUILD_TOKEN }}` for `Create Release` step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for aecdbd9f75562a152154600c4220e03e9d3cf07c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->