### PR TITLE
patch: Add name attribute to MaskedResizableInput and fix price parsing

### DIFF
--- a/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/Products/components/ProductItem/ProductItemEdit.tsx
+++ b/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/Products/components/ProductItem/ProductItemEdit.tsx
@@ -216,7 +216,7 @@ export const ProductItemEdit = observer(
           {sliCurrencySymbol}
 
           <MaskedResizableInput
-            name='plm'
+            name='priceInput'
             mask={`num`}
             placeholder='0'
             className={inputClasses}

--- a/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/Products/components/ProductItem/ProductItemEdit.tsx
+++ b/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/Products/components/ProductItem/ProductItemEdit.tsx
@@ -216,6 +216,7 @@ export const ProductItemEdit = observer(
           {sliCurrencySymbol}
 
           <MaskedResizableInput
+            name='plm'
             mask={`num`}
             placeholder='0'
             className={inputClasses}

--- a/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/Services/ServicesList.tsx
+++ b/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/Services/ServicesList.tsx
@@ -56,7 +56,7 @@ const ServiceItem = observer(
 
     const price =
       typeof contractLineItem?.price === 'string'
-        ? parseFloat((contractLineItem.price as string).replace(',', ''))
+        ? parseFloat((contractLineItem.price as string).replace(/,/g, ''))
         : contractLineItem?.price;
 
     return (

--- a/src/store/ContractLineItems/ContractLineItems.store.ts
+++ b/src/store/ContractLineItems/ContractLineItems.store.ts
@@ -295,7 +295,7 @@ export class ContractLineItemsStore implements GroupStore<ServiceLineItem> {
             billingCycle: payload.billingCycle,
             price:
               typeof payload.price === 'string'
-                ? parseFloat(payload.price)
+                ? parseFloat((payload.price as string).replace(/,/g, ''))
                 : payload.price,
             quantity: payload.quantity,
             serviceEnded: payload.serviceEnded,


### PR DESCRIPTION
- Added 'name' attribute to MaskedResizableInput in ProductItemEdit.tsx
- Fixed price parsing to handle multiple commas in ServicesList.tsx and ContractLineItems.store.ts
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `name` attribute to `MaskedResizableInput` and fix price parsing for multiple commas in `ServicesList.tsx` and `ContractLineItems.store.ts`.
> 
>   - **Components**:
>     - Add `name` attribute to `MaskedResizableInput` in `ProductItemEdit.tsx`.
>   - **Price Parsing**:
>     - Fix price parsing to handle multiple commas in `ServicesList.tsx` and `ContractLineItems.store.ts` by using `replace(/,/g, '')`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 28239141f832e21017c9fdb27db3e2db27d3c6f5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->