### PR TITLE
patch: fix build trigger on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
 
   build-frontera-dev-amd64:
     runs-on: ubicloud-standard-2
-    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) }}
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     needs: [prepare]
     outputs:
       digest: ${{ steps.digest.outputs.value }}
@@ -110,7 +110,7 @@ jobs:
 
   build-frontera-dev-arm64:
     runs-on: ubicloud-standard-2-arm
-    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) }}
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     needs: [prepare]
     outputs:
       digest: ${{ steps.digest.outputs.value }}
@@ -431,7 +431,7 @@ jobs:
   # Create multi-arch manifest for frontera-dev
   create-frontera-dev-manifest:
     needs: [prepare, build-frontera-dev-amd64, build-frontera-dev-arm64]
-    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) }}
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubicloud-standard-2
     steps:
       - name: Checkout
@@ -492,7 +492,7 @@ jobs:
   # Create multi-arch manifest for frontera-prod
   create-frontera-prod-manifest:
     needs: [prepare, build-frontera-prod-amd64, build-frontera-prod-arm64]
-    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) }}
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubicloud-standard-2
     steps:
       - name: Checkout
@@ -553,7 +553,7 @@ jobs:
   # Create multi-arch manifest for middleware
   create-middleware-manifest:
     needs: [prepare, build-middleware-amd64, build-middleware-arm64]
-    if: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) }}
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubicloud-standard-2
     steps:
       - name: Checkout


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes build trigger condition for release events in `build.yml` by simplifying `if` condition syntax.
> 
>   - **Workflow Changes**:
>     - Removed `${{ }}` syntax from `if` conditions in `build.yml` for `build-frontera-dev-amd64`, `build-frontera-dev-arm64`, and `create-frontera-dev-manifest` jobs.
>     - Applied the same change to `create-frontera-prod-manifest` and `create-middleware-manifest` jobs.
>   - **Behavior**:
>     - Fixes build trigger condition for release events by simplifying the `if` condition syntax.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 3a600e526d93495bff062b5152aa80dfc6899f40. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->