### PR TITLE
patch: rename sidesection to leftsection to trigger build cache invalidation

### DIFF
--- a/src/routes/organization/page.tsx
+++ b/src/routes/organization/page.tsx
@@ -14,7 +14,7 @@ import { LoadingScreen } from '@shared/components/SplashScreen/components';
 import { TimelineContextsProvider } from '@organization/components/TimelineContextsProvider';
 
 import { MainSection } from './src/components/MainSection';
-import { SideSection } from './src/components/SideSection';
+import { LeftSection } from './src/components/LeftSection';
 import { Panels, TabsContainer } from './src/components/Tabs';
 import { RelationshipPicker } from './src/components/RelationshipPicker';
 import { OrganizationTimelineWithActionsContext } from './src/components/Timeline/OrganizationTimelineWithActionsContext';
@@ -94,12 +94,12 @@ export const OrganizationPage = observer(() => {
       </div>
       <div className='relative flex h-full'>
         <TimelineContextsProvider id={id}>
-          <SideSection>
+          <LeftSection>
             <TabsContainer>
               <TopNav />
               <Panels tab={searchParams.get('tab') ?? 'about'} />
             </TabsContainer>
-          </SideSection>
+          </LeftSection>
 
           <MainSection>
             <OrganizationTimelineWithActionsContext />

--- a/src/routes/organization/src/components/LeftSection/LeftSection.tsx
+++ b/src/routes/organization/src/components/LeftSection/LeftSection.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 
 import { cn } from '@ui/utils/cn';
 
-export function SideSection({ children }: { children: React.ReactNode }) {
+export function LeftSection({ children }: { children: React.ReactNode }) {
   const [searchParams] = useSearchParams();
   const viewMode = searchParams.get('viewMode');
 

--- a/src/routes/organization/src/components/LeftSection/index.ts
+++ b/src/routes/organization/src/components/LeftSection/index.ts
@@ -1,0 +1,1 @@
+export { LeftSection } from './LeftSection';

--- a/src/routes/organization/src/components/SideSection/index.ts
+++ b/src/routes/organization/src/components/SideSection/index.ts
@@ -1,1 +1,0 @@
-export { SideSection } from './SideSection';


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `SideSection` to `LeftSection` to trigger build cache invalidation.
> 
>   - **Renaming**:
>     - Rename `SideSection` to `LeftSection` in `page.tsx` and `LeftSection.tsx`.
>     - Update import paths and usage in `page.tsx`.
>     - Rename file `SIdeSection.tsx` to `LeftSection.tsx` and update export in `index.ts`.
>   - **Misc**:
>     - Delete `index.ts` in `SideSection` directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 92bf596f331da944cc7dc8d264ad8694a204e5a5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->