### PR TITLE
patch: Adjust height of OrganizationPage container to fit viewport

### DIFF
--- a/src/routes/organization/page.tsx
+++ b/src/routes/organization/page.tsx
@@ -58,7 +58,7 @@ export const OrganizationPage = observer(() => {
   const src = organization?.value.iconUrl || organization?.value.logoUrl;
 
   return (
-    <div className='relative flex flex-col h-full'>
+    <div className='relative flex flex-col h-[calc(100vh-42px)]'>
       <div className='w-full bg-white border-b border-grayModern-200 px-4 min-h-[42px] flex items-center gap-2'>
         <div className='flex items-center gap-2'>
           {src && imgStatus !== 'error' ? (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjust container height in `page.tsx` to fit viewport minus header height.
> 
>   - **UI Adjustment**:
>     - In `page.tsx`, change container height from `h-full` to `h-[calc(100vh-42px)]` to fit viewport minus header height.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for fbe0ed4741e1a9a8a5f03dca359a3ca1cac6255c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->