### PR TITLE
patch: Remove viewMode parameter when closing DocumentEditor

### DIFF
--- a/src/routes/organization/src/components/DocumentEditor/DocumentEditor.tsx
+++ b/src/routes/organization/src/components/DocumentEditor/DocumentEditor.tsx
@@ -75,6 +75,7 @@ export const DocumentEditor = observer(() => {
   const closeEditor = () => {
     setParams((prev) => {
       prev.delete('doc');
+      prev.delete('viewMode');
 
       return prev;
     });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes `viewMode` parameter from URL when closing the DocumentEditor in `DocumentEditor.tsx`.
> 
>   - **Behavior**:
>     - Removes `viewMode` parameter from URL when `closeEditor()` is called in `DocumentEditor.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 661d750ce05f7c702ec4f8d45fec704f4c06ad45. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->