### PR TITLE
patch: Removed service.description and displayed only skuName

### DIFF
--- a/src/routes/src/components/Invoice/ServicesTable.tsx
+++ b/src/routes/src/components/Invoice/ServicesTable.tsx
@@ -72,8 +72,8 @@ export function ServicesTable({
               <div className={'flex w-full'}>
                 <div className='w-1/2 '>
                   <div className='text-left text-sm capitalize font-medium leading-5'>
-                    {(service as InvoiceLine)?.skuName ?? ''}
-                    {service?.description ?? 'Unnamed'}
+                    {(service as InvoiceLine)?.skuName ?? 'Unnamed'}
+                    {/* {service?.description ?? 'Unnamed'} */}
                   </div>
                   <div>
                     {isGenerated &&


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed `service.description` display in `ServicesTable`, now only showing `skuName`.
> 
>   - **Behavior**:
>     - Removed `service.description` display in `ServicesTable`.
>     - Now only displays `skuName` or 'Unnamed' if `skuName` is not available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for ee6807d98749667669fe7eed3e97c985eb3c50c8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->