### PR TITLE
fix

### DIFF
--- a/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/Products/components/ProductCard.tsx
+++ b/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/Products/components/ProductCard.tsx
@@ -42,7 +42,11 @@ export const ProductCard = observer(
       );
     });
 
-    const liveServices = thisGroupLineItems;
+    const liveServices = thisGroupLineItems?.filter(
+      (service) =>
+        !service?.tempValue?.serviceEnded ||
+        !DateTimeUtils.isPast(service?.tempValue?.serviceEnded),
+    );
 
     const closedServices = thisGroupLineItems?.filter(
       (service) => service?.tempValue?.closed,
@@ -57,13 +61,7 @@ export const ProductCard = observer(
       liveServices.every((service) => service?.tempValue?.closed);
 
     const handleCloseChange = (closed: boolean) => {
-      liveServices?.forEach((service) => {
-        (service as ContractLineItemStore)?.updateTemp((prev) => ({
-          ...prev,
-          closed,
-        }));
-      });
-      closedServices?.forEach((service) => {
+      thisGroupLineItems?.forEach((service) => {
         (service as ContractLineItemStore)?.updateTemp((prev) => ({
           ...prev,
           closed,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `liveServices` filtering and update logic in `ProductCard.tsx` to handle service end dates and closure state updates.
> 
>   - **Behavior**:
>     - `liveServices` now excludes services with `serviceEnded` in the past in `ProductCard.tsx`.
>     - `handleCloseChange` updates `closed` state for all `thisGroupLineItems`, not just `liveServices`.
>   - **Functions**:
>     - Modify `liveServices` filter logic in `ProductCard.tsx` to check `serviceEnded` date.
>     - Update `handleCloseChange` to iterate over `thisGroupLineItems` instead of `liveServices` and `closedServices`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 04cbb4a078ac161430e22c5d24f921eb12e4a801. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->