### PR TITLE
fix: show more button from about panel

### DIFF
--- a/src/ui/presentation/TruncatedText/TruncatedText.tsx
+++ b/src/ui/presentation/TruncatedText/TruncatedText.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useLayoutEffect } from 'react';
 
 import { cn } from '@ui/utils/cn.ts';
 
@@ -15,18 +15,20 @@ export const TruncatedText = ({
 }: TruncatedTextProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [showButton, setShowButton] = useState(false);
-  const textRef = useRef<HTMLDivElement>(null);
+  const textRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    if (textRef.current) {
-      const lineHeight = parseInt(
-        getComputedStyle(textRef.current).lineHeight,
-        10,
-      );
-      const maxHeight = lineHeight * maxLines;
+  useLayoutEffect(() => {
+    setTimeout(() => {
+      if (textRef.current) {
+        const lineHeight = parseInt(
+          getComputedStyle(textRef.current).lineHeight,
+          10,
+        );
+        const maxHeight = lineHeight * maxLines;
 
-      setShowButton(textRef.current.scrollHeight > maxHeight);
-    }
+        setShowButton(textRef.current.scrollHeight > maxHeight);
+      }
+    }, 100);
   }, [text, maxLines]);
 
   const toggleExpand = () => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switches to `useLayoutEffect` in `TruncatedText.tsx` for accurate button visibility calculation post-DOM update, with a 100ms delay.
> 
>   - **Behavior**:
>     - Replaces `useEffect` with `useLayoutEffect` in `TruncatedText.tsx` to ensure DOM updates before calculating button visibility.
>     - Introduces `setTimeout` in `useLayoutEffect` to delay visibility calculation by 100ms.
>   - **Type Safety**:
>     - Updates `textRef` type to `HTMLDivElement | null` in `TruncatedText.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 0a6c6cf19bd55a26e149653e6503029c8f439879. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->