### PR TITLE
fix:change position for domains options

### DIFF
--- a/src/routes/src/components/OrganizationDetails/components/domains/Domains.tsx
+++ b/src/routes/src/components/OrganizationDetails/components/domains/Domains.tsx
@@ -154,7 +154,7 @@ export const Domains = observer(({ id }: { id: string }) => {
                   />
                 </MenuButton>
 
-                <MenuList className='min-w-[100px]'>
+                <MenuList side='bottom' align='start' className='min-w-[100px]'>
                   {index === 0 && (
                     <MenuItem
                       onClick={() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `MenuList` positioning in `Domains.tsx` to align menu options to the start and position them at the bottom.
> 
>   - **UI/UX Improvement**:
>     - In `Domains.tsx`, change `MenuList` positioning by adding `side='bottom'` and `align='start'` to ensure menu options appear at the bottom and aligned to the start.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for ce3cf35b99c1637a96b9ef87626d1a5ec454c5a4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->