### PR TITLE
fix displayed shortcuts for archive a task

### DIFF
--- a/src/routes/src/components/CommandMenu/commands/TaskCommands.tsx
+++ b/src/routes/src/components/CommandMenu/commands/TaskCommands.tsx
@@ -115,7 +115,9 @@ export const TaskCommands = observer(() => {
           rightAccessory={
             <>
               <CommandKbd />
-              <Kbd>D</Kbd>
+              <Kbd>
+                <Icon name='delete' className='text-inherit size-3' />
+              </Kbd>
             </>
           }
         >


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update displayed shortcut for archiving a task in `TaskCommands.tsx` to use a delete icon instead of the letter `D`.
> 
>   - **UI Update**:
>     - In `TaskCommands.tsx`, updated the displayed shortcut for archiving a task to use an icon instead of the letter `D`.
>     - Replaced `<Kbd>D</Kbd>` with `<Kbd><Icon name='delete' className='text-inherit size-3' /></Kbd>` for the archive task command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for ed465c50da82837b76bc66acc49e9dd2e9c10c71. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->