### PR TITLE
fix: make default view kanban board for opportunities

### DIFF
--- a/src/routes/src/components/RootSidenav/components/sections/GeneralViewsSection.tsx
+++ b/src/routes/src/components/RootSidenav/components/sections/GeneralViewsSection.tsx
@@ -44,9 +44,6 @@ export const GeneralViewsSection = observer(
     const contractsView = store.tableViewDefs.getById(
       store.tableViewDefs.contractsPreset ?? '',
     );
-    const opportunitiesView = store.tableViewDefs.getById(
-      store.tableViewDefs.opportunitiesTablePreset ?? '',
-    );
 
     const invoicesViews = [
       store.tableViewDefs.getById(
@@ -118,11 +115,7 @@ export const GeneralViewsSection = observer(
               label='Opportunities'
               isActive={isOpportinitiesActive}
               dataTest={`side-nav-item-opportunities`}
-              onClick={() =>
-                handleItemClick(
-                  `prospects?show=finder&preset=${opportunitiesView?.value?.id}`,
-                )
-              }
+              onClick={() => handleItemClick(`prospects`)}
               icon={(isActive) => (
                 <Icon
                   name='coins-stacked-01'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set default view to kanban board for opportunities in `GeneralViewsSection.tsx`.
> 
>   - **Behavior**:
>     - In `GeneralViewsSection.tsx`, the `onClick` handler for the 'Opportunities' item now navigates to `prospects` without a preset parameter, setting the default view to a kanban board.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 7eca32b2b006cca36f02ee53c98041ac083fd636. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->