### PR TITLE
feat:Add navigation between orgs from orgView

### DIFF
--- a/src/routes/organization/page.tsx
+++ b/src/routes/organization/page.tsx
@@ -1,11 +1,14 @@
-import { useState } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 
+import { useKey } from 'rooks';
 import { observer } from 'mobx-react-lite';
+import { useLocalStorage } from 'usehooks-ts';
 
 import { cn } from '@ui/utils/cn';
 import { Icon } from '@ui/media/Icon';
 import { Image } from '@ui/media/Image/Image';
+import { IconButton } from '@ui/form/IconButton';
 import { useStore } from '@shared/hooks/useStore';
 import { TopNav } from '@organization/components/TopNav';
 import { UserPresence } from '@shared/components/UserPresence';
@@ -21,7 +24,23 @@ import { OrganizationTimelineWithActionsContext } from './src/components/Timelin
 
 export const OrganizationPage = observer(() => {
   const navigate = useNavigate();
+  const [lastKnownIndex, setLastKnownIndex] = useState<number>(0);
   const params = useParams();
+  const [lastActivePosition] = useLocalStorage(
+    `customeros-player-last-position`,
+    { root: 'finder' },
+  );
+
+  const getLastPreset = useCallback(() => {
+    const preset = lastActivePosition.root.split('=')?.[1];
+
+    if (preset) {
+      return preset;
+    }
+
+    return store.tableViewDefs.organizationsPreset;
+  }, [lastActivePosition.root]);
+
   const [searchParams] = useSearchParams();
   const [imgStatus, setImgStatus] = useState<'loading' | 'loaded' | 'error'>(
     'loading',
@@ -57,6 +76,73 @@ export const OrganizationPage = observer(() => {
   const organization = store.organizations.getById(id!);
   const src = organization?.value.iconUrl || organization?.value.logoUrl;
 
+  const preset = (() => {
+    const lastPreset = getLastPreset();
+    const { targetsPreset, organizationsPreset, customersPreset } =
+      store.tableViewDefs;
+
+    if (
+      [targetsPreset, organizationsPreset, customersPreset].includes(lastPreset)
+    ) {
+      return lastPreset;
+    }
+
+    return organizationsPreset;
+  })();
+
+  const data = store.organizations.getViewById(preset ?? '');
+
+  const currentIndex = useMemo(() => {
+    const index = data.findIndex((item) => item.id === id);
+
+    if (index === -1) {
+      return Math.min(lastKnownIndex, data.length - 1);
+    }
+
+    // If the difference between current index and last known index is greater than 1,
+    // use the last known index to prevent jumping around
+    if (Math.abs(index - lastKnownIndex) > 1) {
+      return lastKnownIndex;
+    }
+
+    setLastKnownIndex(index);
+
+    return index;
+  }, [data, id, store.organizations.version, lastKnownIndex]);
+
+  const total = store.organizations.availableCounts.get(preset ?? '');
+
+  const navigateToOrg = async (direction: 'prev' | 'next') => {
+    const newIndex =
+      direction === 'prev'
+        ? (currentIndex - 1 + data.length) % data.length
+        : (currentIndex + 1) % data.length;
+
+    if (
+      direction === 'next' &&
+      newIndex === 0 &&
+      data.length < (total ?? data.length)
+    ) {
+      await store.organizations.loadNext(
+        preset ?? store.tableViewDefs.organizationsPreset!,
+      );
+    }
+
+    navigate(`/organization/${data[newIndex].id}`);
+  };
+
+  useKey('d', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    navigateToOrg('next');
+  });
+
+  useKey('a', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    navigateToOrg('prev');
+  });
+
   return (
     <div className='relative flex flex-col h-[calc(100vh-42px)]'>
       <div className='w-full bg-white border-b border-grayModern-200 px-4 min-h-[42px] flex items-center gap-2'>
@@ -83,9 +169,36 @@ export const OrganizationPage = observer(() => {
           )}
           <h1 className='font-medium text-md'>{organization?.name}</h1>
         </div>
+
         <RelationshipPicker />
         <StagePicker />
+
         <div className='flex-1 min-h-[28px]' />
+        <div className='flex items-center gap-1 ml-2 text-sm'>
+          <span>{currentIndex + 1}</span>
+          <span>/</span>
+          <span className='text-grayModern-500'>{total}</span>
+        </div>
+        <div className='flex items-center gap-1 ml-2'>
+          <IconButton
+            size='xxs'
+            title='Previous company (A)'
+            aria-label='Previous company'
+            isDisabled={currentIndex === 0}
+            onClick={() => navigateToOrg('prev')}
+            className='p-1 hover:bg-grayModern-100 rounded'
+            icon={<Icon name='chevron-up' className='text-grayModern-700' />}
+          />
+          <IconButton
+            size='xxs'
+            title='Next company (D)'
+            aria-label='Next company'
+            icon={<Icon name='chevron-down' />}
+            onClick={() => navigateToOrg('next')}
+            className='p-1 hover:bg-grayModern-100 rounded'
+            isDisabled={currentIndex === (total ?? data.length) - 1}
+          />
+        </div>
         {organization?.id && (
           <UserPresence
             channelName={`organization_presence:${organization?.id}`}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds navigation between organizations in `OrganizationPage` with buttons and keyboard shortcuts, managing state and data loading efficiently.
> 
>   - **Navigation**:
>     - Adds `navigateToOrg` function in `OrganizationPage` to navigate between organizations using 'prev' and 'next' directions.
>     - Implements keyboard shortcuts 'a' and 'd' for previous and next organization navigation using `useKey`.
>     - Adds `IconButton` components for navigation with chevron icons and disables them at boundaries.
>   - **State Management**:
>     - Introduces `lastKnownIndex` state to track the last known organization index.
>     - Uses `useLocalStorage` to retrieve `lastActivePosition` for preset determination.
>     - Calculates `currentIndex` using `useMemo` to prevent jumping around.
>   - **Data Handling**:
>     - Determines `preset` using `getLastPreset` and fallback logic.
>     - Loads more data if navigating to the next organization and at the end of the current data set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 0a76bf16be2706ba69493deef4f0cd24d582b761. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->