### PR TITLE
feat:keep same tab while navigate between orgs

### DIFF
--- a/src/routes/finder/src/components/Search/Search.tsx
+++ b/src/routes/finder/src/components/Search/Search.tsx
@@ -286,7 +286,7 @@ export const Search = observer(() => {
       {tableViewDef?.value.tableId === TableIdType.UpcomingInvoices && (
         <IconButton
           size='xs'
-          variant='outline'
+          variant='ghost'
           icon={<Icon name='download-02' />}
           aria-label='Download upcoming invoices'
           onClick={() => {

--- a/src/routes/organization/page.tsx
+++ b/src/routes/organization/page.tsx
@@ -23,12 +23,20 @@ import { RelationshipPicker } from './src/components/RelationshipPicker';
 import { OrganizationTimelineWithActionsContext } from './src/components/Timeline/OrganizationTimelineWithActionsContext';
 
 export const OrganizationPage = observer(() => {
+  const store = useStore();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const [lastKnownIndex, setLastKnownIndex] = useState<number>(0);
   const params = useParams();
+  const { id } = params;
+
   const [lastActivePosition] = useLocalStorage(
     `customeros-player-last-position`,
     { root: 'finder' },
+  );
+
+  const [lastKnownIndex, setLastKnownIndex] = useState<number>(0);
+  const [imgStatus, setImgStatus] = useState<'loading' | 'loaded' | 'error'>(
+    'loading',
   );
 
   const getLastPreset = useCallback(() => {
@@ -41,14 +49,7 @@ export const OrganizationPage = observer(() => {
     return store.tableViewDefs.organizationsPreset;
   }, [lastActivePosition.root]);
 
-  const [searchParams] = useSearchParams();
-  const [imgStatus, setImgStatus] = useState<'loading' | 'loaded' | 'error'>(
-    'loading',
-  );
-
-  const store = useStore();
-
-  const { id } = params;
+  const panel = searchParams.get('tab') ?? 'about';
 
   if (typeof id === 'undefined') {
     navigate('/finder');
@@ -128,7 +129,7 @@ export const OrganizationPage = observer(() => {
       );
     }
 
-    navigate(`/organization/${data[newIndex].id}`);
+    navigate(`/organization/${data[newIndex].id}?tab=${panel}`);
   };
 
   useKey('d', (e) => {
@@ -177,9 +178,9 @@ export const OrganizationPage = observer(() => {
         <div className='flex items-center gap-1 ml-2 text-sm'>
           <span>{currentIndex + 1}</span>
           <span>/</span>
-          <span className='text-grayModern-500'>{total}</span>
+          <span className='text-grayModern-500'>{total?.toLocaleString()}</span>
         </div>
-        <div className='flex items-center gap-1 ml-2'>
+        <div className='flex items-center gap-1'>
           <IconButton
             size='xxs'
             title='Previous company (A)'
@@ -210,7 +211,7 @@ export const OrganizationPage = observer(() => {
           <LeftSection>
             <TabsContainer>
               <TopNav />
-              <Panels tab={searchParams.get('tab') ?? 'about'} />
+              <Panels tab={panel} />
             </TabsContainer>
           </LeftSection>
 

--- a/src/routes/src/components/Invoice/EmptyState/EmptyState.tsx
+++ b/src/routes/src/components/Invoice/EmptyState/EmptyState.tsx
@@ -55,7 +55,7 @@ export const EmptyState = observer(
           <p className='text-grayModern-700 text-md font-semibold mb-1'>
             No paper trails yet
           </p>
-          <p className='text-sm my-1 max-w-[360px] text-center'>
+          <div className='text-sm my-1 max-w-[360px] text-center'>
             {cashflowAgent?.isActive ? (
               <>
                 <p>
@@ -90,7 +90,7 @@ export const EmptyState = observer(
                 </span>
               </>
             )}
-          </p>
+          </div>
           <Button
             variant='outline'
             colorScheme='primary'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Preserve active tab state when navigating between organizations by updating navigation logic and UI components.
> 
>   - **Navigation**:
>     - In `page.tsx`, update navigation to include `tab` parameter, preserving active tab when switching organizations.
>     - Modify `navigateToOrg` function to append `?tab=${panel}` to URLs.
>   - **UI Components**:
>     - Change `IconButton` variant from `outline` to `ghost` in `Search.tsx`.
>     - Replace `<p>` with `<div>` for text container in `EmptyState.tsx` for better styling consistency.
>   - **Misc**:
>     - Remove redundant state initializations and reorder hooks in `page.tsx` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 69ea465ba2a747856f25ad6c17f70a322d8fabc3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->