### PR TITLE
add navigate from billing details to cashflow agent

### DIFF
--- a/src/routes/src/components/Invoice/components/BankingDetails.tsx
+++ b/src/routes/src/components/Invoice/components/BankingDetails.tsx
@@ -1,6 +1,12 @@
-import { FC } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-import { Currency, BankAccount } from '@graphql/types';
+import { useStore } from '@shared/hooks/useStore';
+import {
+  Currency,
+  AgentType,
+  BankAccount,
+  CapabilityType,
+} from '@graphql/types';
 
 type InvoiceHeaderProps = {
   currency?: string;
@@ -37,11 +43,13 @@ const getBankDetails = (
   return details;
 };
 
-export const BankingDetails: FC<InvoiceHeaderProps> = ({
+export const BankingDetails = ({
   availableBankAccount,
   currency,
   invoiceNumber,
-}) => {
+}: InvoiceHeaderProps) => {
+  const store = useStore();
+  const navigate = useNavigate();
   const bankDetails: { label: string; value: string } = getBankDetails(
     currency,
     availableBankAccount,
@@ -53,9 +61,24 @@ export const BankingDetails: FC<InvoiceHeaderProps> = ({
     currency === Currency.Eur
       ? availableBankAccount?.iban
       : availableBankAccount?.accountNumber;
+  const cashflowGuardianAgent = store.agents.getFirstAgentByType(
+    AgentType.CashflowGuardian,
+  );
+  const getGenerateInvoiceCapability = store.agents
+    .getById(cashflowGuardianAgent?.id ?? '')
+    ?.value.capabilities.find(
+      (capability) => capability.type === CapabilityType.GenerateInvoice,
+    );
 
   return (
-    <div className='flex flex-col border-t border-grayModern-300 py-2'>
+    <div
+      className='flex flex-col border-t border-grayModern-300 py-2 cursor-pointer'
+      onClick={() => {
+        navigate(
+          `/agents/${cashflowGuardianAgent?.id}/${getGenerateInvoiceCapability?.id}`,
+        );
+      }}
+    >
       <span className='text-xs font-semibold'>Bank transfer</span>
       <div className='flex justify-between'>
         <div className='flex flex-col'>

--- a/src/routes/src/components/Invoice/components/BankingDetails.tsx
+++ b/src/routes/src/components/Invoice/components/BankingDetails.tsx
@@ -74,9 +74,11 @@ export const BankingDetails = ({
     <div
       className='flex flex-col border-t border-grayModern-300 py-2 cursor-pointer'
       onClick={() => {
-        navigate(
-          `/agents/${cashflowGuardianAgent?.id}/${getGenerateInvoiceCapability?.id}`,
-        );
+        if (getGenerateInvoiceCapability) {
+          navigate(
+            `/agents/${cashflowGuardianAgent?.id}/${getGenerateInvoiceCapability?.id}`,
+          );
+        }
       }}
     >
       <span className='text-xs font-semibold'>Bank transfer</span>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add navigation to `BankingDetails` component to navigate to cashflow agent's page on click if `GenerateInvoice` capability exists.
> 
>   - **Behavior**:
>     - Adds navigation to `BankingDetails` component, allowing click to navigate to cashflow agent's page if `GenerateInvoice` capability exists.
>     - Uses `useNavigate` from `react-router-dom` and `useStore` to access agent data.
>   - **Logic**:
>     - Retrieves `cashflowGuardianAgent` using `store.agents.getFirstAgentByType(AgentType.CashflowGuardian)`.
>     - Checks for `GenerateInvoice` capability in `cashflowGuardianAgent` before navigating.
>   - **UI**:
>     - Adds `cursor-pointer` class to make `BankingDetails` clickable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for add9104d175dc3e4dd5de9c81adfe36cf34e2876. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->