### PR TITLE
fix avatar not loading while navigate between orgs + add tooltips for download invoces

### DIFF
--- a/src/routes/finder/src/components/Search/Search.tsx
+++ b/src/routes/finder/src/components/Search/Search.tsx
@@ -288,7 +288,12 @@ export const Search = observer(() => {
           size='xs'
           variant='ghost'
           icon={<Icon name='download-02' />}
-          aria-label='Download upcoming invoices'
+          aria-label='Download csv invoices'
+          title={
+            tableViewDef?.value.tableId === TableIdType.UpcomingInvoices
+              ? 'Download CSV of future invoices'
+              : 'Download CSV of past invoices'
+          }
           onClick={() => {
             tableViewDef?.value.tableId === TableIdType.UpcomingInvoices
               ? store.files.downloadUpcomingInvoice()

--- a/src/routes/organization/page.tsx
+++ b/src/routes/organization/page.tsx
@@ -148,7 +148,7 @@ export const OrganizationPage = observer(() => {
     <div className='relative flex flex-col h-[calc(100vh-42px)]'>
       <div className='w-full bg-white border-b border-grayModern-200 px-4 min-h-[42px] flex items-center gap-2'>
         <div className='flex items-center gap-2'>
-          {src && imgStatus !== 'error' ? (
+          {src ? (
             <Image
               src={src}
               width={22}


### PR DESCRIPTION
…download csv invoices
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix avatar loading issue and add tooltips for invoice downloads in `Search.tsx` and `page.tsx`.
> 
>   - **Avatar Loading**:
>     - Fix avatar not loading by removing `imgStatus !== 'error'` condition in `page.tsx`.
>   - **Tooltips for Invoices**:
>     - Add tooltips for download button in `Search.tsx` to differentiate between future and past invoices.
>     - Update `aria-label` to 'Download csv invoices' in `Search.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for cdfa5ddd7606c8436d45e3d523760f4c035c667c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->