### PR TITLE
Mihai/cos 7104 allow creating new opportunities on tasks

### DIFF
--- a/scripts/codegen-graphql-stores.ts
+++ b/scripts/codegen-graphql-stores.ts
@@ -24,6 +24,7 @@ const config: CodegenConfig = {
     './src/store/**/*.graphql',
     './src/infra/**/*.graphql',
     '!./src/infra/repositories/mailstack',
+    '!./src/infra/repositories/realtime',
   ],
   generates: {
     'src/routes/src/types/__generated__/graphql.types.ts': {

--- a/src/domain/usecases/command-menu/choose-org-for-opportunity.usecase.ts
+++ b/src/domain/usecases/command-menu/choose-org-for-opportunity.usecase.ts
@@ -86,6 +86,7 @@ export class ChooseOrgForOpportunityUsecase {
         `${org.value.name}'s opportunity`,
       internalType: InternalType.Nbo,
       externalStage: isInternalStage ? '' : stage,
+      taskIds: [this.store.ui.commandMenu.context?.meta?.taskId],
     });
 
     span.end();

--- a/src/domain/usecases/command-menu/choose-org-for-opportunity.usecase.ts
+++ b/src/domain/usecases/command-menu/choose-org-for-opportunity.usecase.ts
@@ -81,7 +81,9 @@ export class ChooseOrgForOpportunityUsecase {
       // @ts-expect-error this will be autofixed when Opportunity store will use OpportunityDatum
       organization: org.value,
       id: org.value.id,
-      name: `${org.value.name}'s opportunity`,
+      name:
+        this.store.ui.commandMenu.context?.meta?.name ||
+        `${org.value.name}'s opportunity`,
       internalType: InternalType.Nbo,
       externalStage: isInternalStage ? '' : stage,
     });
@@ -90,5 +92,6 @@ export class ChooseOrgForOpportunityUsecase {
 
     this.store.ui.commandMenu.setOpen(false);
     this.store.ui.commandMenu.setType('OpportunityHub');
+    this.store.ui.commandMenu.clearContext();
   }
 }

--- a/src/routes/src/components/CommandMenu/commands/task/LinkOpportunity.tsx
+++ b/src/routes/src/components/CommandMenu/commands/task/LinkOpportunity.tsx
@@ -5,6 +5,7 @@ import { EditTaskUsecase } from '@domain/usecases/command-menu/task/edit-task.us
 
 import { Icon } from '@ui/media/Icon';
 import { useStore } from '@shared/hooks/useStore';
+import { PlusCircle } from '@ui/media/icons/PlusCircle';
 import { Command, CommandItem, CommandInput } from '@ui/overlay/CommandMenu';
 
 export const LinkOpportunity = observer(() => {
@@ -24,6 +25,11 @@ export const LinkOpportunity = observer(() => {
   };
 
   const opportunities = store.opportunities.toArray();
+  const filteredOpportunities = opportunities.filter(
+    (op) =>
+      !!op.value.name.length &&
+      op.value.name?.toLowerCase().includes(usecase.searchTerm.toLowerCase()),
+  );
 
   return (
     <Command shouldFilter={false} label='Assign task...'>
@@ -39,30 +45,41 @@ export const LinkOpportunity = observer(() => {
         }}
       />
       <Command.List>
-        {opportunities
-          .filter((op) =>
-            op.value.name
-              ?.toLowerCase()
-              .includes(usecase.searchTerm.toLowerCase()),
-          )
-          .map((op) => (
-            <CommandItem
-              key={op.value.id}
-              dataValue={`${op.value.name} - ${op.value.id}`}
-              rightAccessory={
-                task?.value.opportunityIds.includes(op.value.id) ? (
-                  <Icon name='check' />
-                ) : null
-              }
-              onSelect={() => {
-                usecase.setProperty('opportunityIds', op.value.id);
-                usecase.execute();
-                handleClose();
-              }}
-            >
-              {op.value.name}
-            </CommandItem>
-          ))}
+        {filteredOpportunities.map((op) => (
+          <CommandItem
+            key={op.value.id}
+            dataValue={`${op.value.name} - ${op.value.id}`}
+            rightAccessory={
+              task?.value.opportunityIds.includes(op.value.id) ? (
+                <Icon name='check' />
+              ) : null
+            }
+            onSelect={() => {
+              usecase.setProperty('opportunityIds', op.value.id);
+              usecase.execute();
+              handleClose();
+            }}
+          >
+            {op.value.name}
+          </CommandItem>
+        ))}
+        {filteredOpportunities.length === 0 && (
+          <CommandItem
+            leftAccessory={<PlusCircle />}
+            onSelect={() => {
+              store.ui.commandMenu.setType('ChooseOpportunityStage');
+              store.ui.commandMenu.setContext({
+                ...context,
+                meta: {
+                  name: usecase.searchTerm,
+                  taskId: task.value.id,
+                },
+              });
+            }}
+          >
+            Create new opportunity "{usecase.searchTerm}"
+          </CommandItem>
+        )}
       </Command.List>
     </Command>
   );

--- a/src/routes/src/types/__generated__/graphql.types.ts
+++ b/src/routes/src/types/__generated__/graphql.types.ts
@@ -1621,6 +1621,14 @@ export type EmailParticipant = {
   type?: Maybe<Scalars['String']['output']>;
 };
 
+export type EmailProfile = {
+  __typename?: 'EmailProfile';
+  email: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  profilePhotoUrl: Scalars['String']['output'];
+  profilePhotoUrlId: Scalars['String']['output'];
+};
+
 /**
  * Describes an email address associated with a `Contact` in customerOS.
  * **An `update` object.**
@@ -3767,6 +3775,7 @@ export type OpportunitySaveInput = {
   opportunityId?: InputMaybe<Scalars['ID']['input']>;
   organizationId?: InputMaybe<Scalars['ID']['input']>;
   ownerId?: InputMaybe<Scalars['ID']['input']>;
+  taskId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type OpportunityUpdateInput = {
@@ -4345,6 +4354,7 @@ export type Query = {
   dashboard_RevenueAtRisk?: Maybe<DashboardRevenueAtRisk>;
   dashboard_TimeToOnboard?: Maybe<DashboardTimeToOnboard>;
   email: Email;
+  email_ProfilePhoto: Array<EmailProfile>;
   externalMeetings: MeetingsPage;
   externalSystemInstances: Array<ExternalSystemInstance>;
   flow: Flow;
@@ -4501,6 +4511,10 @@ export type QueryDashboard_TimeToOnboardArgs = {
 
 export type QueryEmailArgs = {
   id: Scalars['ID']['input'];
+};
+
+export type QueryEmail_ProfilePhotoArgs = {
+  emails: Array<Scalars['String']['input']>;
 };
 
 export type QueryExternalMeetingsArgs = {

--- a/src/store/Opportunities/Opportunities.store.ts
+++ b/src/store/Opportunities/Opportunities.store.ts
@@ -131,6 +131,7 @@ export class OpportunitiesStore implements GroupStore<Opportunity> {
           organizationId: payload.id,
           internalType: draft.value.internalType,
           externalStage: draft.value.externalStage,
+          taskIds: draft.value.taskIds,
         } as OpportunityCreateInput,
       });
 
@@ -158,6 +159,7 @@ export class OpportunitiesStore implements GroupStore<Opportunity> {
         ids: [serverId],
       });
       this.value.get(serverId)?.invalidate();
+
       this.root.ui.toastSuccess(
         `Opportunity created for ${payload.organization?.name}`,
         'create-opportunity-success',

--- a/src/store/Opportunities/Opportunities.store.ts
+++ b/src/store/Opportunities/Opportunities.store.ts
@@ -3,6 +3,7 @@ import { RootStore } from '@store/root';
 import { Transport } from '@infra/transport';
 import { GroupOperation } from '@store/types';
 import { when, runInAction, makeAutoObservable } from 'mobx';
+import { TaskRepository } from '@infra/repositories/core/task';
 import { GroupStore, makeAutoSyncableGroup } from '@store/group-store';
 
 import {
@@ -27,6 +28,7 @@ export class OpportunitiesStore implements GroupStore<Opportunity> {
   subscribe = makeAutoSyncableGroup.subscribe;
   load = makeAutoSyncableGroup.load<Opportunity>();
   private service: OpportunitiesService;
+  private taskRepository = TaskRepository.getInstance();
 
   constructor(public root: RootStore, public transport: Transport) {
     this.service = OpportunitiesService.getInstance(transport);
@@ -131,7 +133,6 @@ export class OpportunitiesStore implements GroupStore<Opportunity> {
           organizationId: payload.id,
           internalType: draft.value.internalType,
           externalStage: draft.value.externalStage,
-          taskIds: draft.value.taskIds,
         } as OpportunityCreateInput,
       });
 
@@ -158,6 +159,18 @@ export class OpportunitiesStore implements GroupStore<Opportunity> {
         action: 'APPEND',
         ids: [serverId],
       });
+
+      if (draft.value.taskIds.length > 0) {
+        this.taskRepository.saveTask({
+          input: {
+            id: draft.value.taskIds[0],
+            opportunityIds: [serverId],
+          },
+        });
+        this.root.tasks
+          .getById(draft.value.taskIds[0])
+          ?.value.opportunityIds.push(serverId);
+      }
       this.value.get(serverId)?.invalidate();
 
       this.root.ui.toastSuccess(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance opportunity creation to link with tasks, update UI and GraphQL types to support task IDs in opportunities.
> 
>   - **Behavior**:
>     - `OpportunitiesStore` in `Opportunities.store.ts` now supports creating opportunities linked to tasks by saving task IDs and updating task opportunity IDs.
>     - `LinkOpportunity` in `LinkOpportunity.tsx` allows creating new opportunities if none match the search term, setting the command menu context with task ID.
>     - `ChooseOrgForOpportunityUsecase` in `choose-org-for-opportunity.usecase.ts` includes task IDs when creating opportunities.
>   - **GraphQL**:
>     - Add `taskId` to `OpportunitySaveInput` in `graphql.types.ts`.
>     - Add `EmailProfile` type and `email_ProfilePhoto` query in `graphql.types.ts`.
>   - **Misc**:
>     - Exclude `realtime` from code generation in `codegen-graphql-stores.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 730a170e49d01bfd6bde7caa0adaf720cccea775. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->