### PR TITLE
replace tooltip on download invoice button

### DIFF
--- a/src/routes/finder/src/components/Search/Search.tsx
+++ b/src/routes/finder/src/components/Search/Search.tsx
@@ -284,22 +284,25 @@ export const Search = observer(() => {
       )}
 
       {tableViewDef?.value.tableType === TableViewType.Invoices && (
-        <IconButton
-          size='xs'
-          variant='ghost'
-          icon={<Icon name='download-02' />}
-          aria-label='Download csv invoices'
-          title={
+        <Tooltip
+          label={
             tableViewDef?.value.tableId === TableIdType.UpcomingInvoices
               ? 'Download CSV of future invoices'
               : 'Download CSV of past invoices'
           }
-          onClick={() => {
-            tableViewDef?.value.tableId === TableIdType.UpcomingInvoices
-              ? store.files.downloadUpcomingInvoice()
-              : store.files.downloadPastInvoice();
-          }}
-        />
+        >
+          <IconButton
+            size='xs'
+            variant='ghost'
+            icon={<Icon name='download-02' />}
+            aria-label='Download csv invoices'
+            onClick={() => {
+              tableViewDef?.value.tableId === TableIdType.UpcomingInvoices
+                ? store.files.downloadUpcomingInvoice()
+                : store.files.downloadPastInvoice();
+            }}
+          />
+        </Tooltip>
       )}
 
       {tableViewDef?.value.tableId !== TableIdType.FlowActions && (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wraps `IconButton` with `Tooltip` in `Search.tsx` for download invoice button to provide context-specific guidance.
> 
>   - **UI Enhancement**:
>     - Wraps `IconButton` with `Tooltip` in `Search.tsx` for download invoice button.
>     - Tooltip displays 'Download CSV of future invoices' or 'Download CSV of past invoices' based on `tableViewDef?.value.tableId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 8a602e4001c97b6d960f2c75a9cd138958b75a09. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->