### PR TITLE
fix: strip spaces from domainInput

### DIFF
--- a/src/ui/presentation/Highlight/Highlight.tsx
+++ b/src/ui/presentation/Highlight/Highlight.tsx
@@ -9,10 +9,13 @@ interface HighlightProps {
 export const Highlight = ({ term, className, children }: HighlightProps) => {
   if (typeof children !== 'string') return <>{children}</>;
 
+  // Strip spaces from the term
+  const strippedTerm = term.replace(/\s+/g, '');
+
   if (
-    !term ||
-    term.length === 0 ||
-    !children.toLowerCase().includes(term.toLowerCase())
+    !strippedTerm ||
+    strippedTerm.length === 0 ||
+    !children.toLowerCase().includes(strippedTerm.toLowerCase())
   ) {
     return <>{children}</>;
   }
@@ -21,7 +24,7 @@ export const Highlight = ({ term, className, children }: HighlightProps) => {
   const escapeRegex = (str: string) =>
     str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-  const safeTerm = escapeRegex(term);
+  const safeTerm = escapeRegex(strippedTerm);
   const regex = new RegExp(`(${safeTerm})`, 'gi');
   const parts = children.split(regex);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Strips spaces from `term` in `Highlight` component to ensure correct highlighting functionality.
> 
>   - **Behavior**:
>     - Strips spaces from `term` in `Highlight` component in `Highlight.tsx` before processing.
>     - Ensures highlight functionality works with terms containing spaces.
>   - **Functions**:
>     - Modifies `Highlight` function to use `strippedTerm` instead of `term` for processing and regex creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 521ce0b2ceb3d741e0c49200f3da0798cddabd7d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->