### PR TITLE
patch: edit document name inline

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 npx lint-staged
+npm run test:unit -- run --silent
 
 if [ $? -ne 0 ]; then
-    echo "Pre-commit hook failed. Aborting the commit."
-    exit 1
+  echo "Pre-commit hook failed. Aborting the commit."
+  exit 1
 fi
 
 exit 0

--- a/src/domain/components/document/document-rename-modal.tsx
+++ b/src/domain/components/document/document-rename-modal.tsx
@@ -11,6 +11,7 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
+  ModalPortal,
   ModalContent,
   ModalOverlay,
   ModalCloseButton,
@@ -40,40 +41,42 @@ export const DocumentRenameModal = observer(
 
     return (
       <Modal open={open} onOpenChange={onOpenChange}>
-        <ModalOverlay />
-        <ModalContent>
-          <ModalCloseButton />
-          <ModalHeader className='font-medium'>Rename document</ModalHeader>
-          <ModalBody>
-            <Input
-              size='xs'
-              placeholder='Document name'
-              value={usecase?.renameValue}
-              invalid={!!usecase?.renameValidation}
-              onChange={(e) => usecase?.setRenameValue(e.target.value)}
-            />
-            {!!usecase?.renameValidation && (
-              <p className='text-xs text-error-500 mt-0.5'>
-                {usecase?.renameValidation}
-              </p>
-            )}
-          </ModalBody>
-          <ModalFooter className='flex gap-3 justify-between'>
-            <Button className='flex-1' onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button
-              className='flex-1'
-              colorScheme='primary'
-              isDisabled={!!usecase?.renameValidation}
-              onClick={() =>
-                usecase?.execute({ onSuccess: () => onOpenChange(false) })
-              }
-            >
-              Rename
-            </Button>
-          </ModalFooter>
-        </ModalContent>
+        <ModalPortal>
+          <ModalOverlay />
+          <ModalContent>
+            <ModalCloseButton />
+            <ModalHeader className='font-medium'>Rename document</ModalHeader>
+            <ModalBody>
+              <Input
+                size='xs'
+                placeholder='Document name'
+                value={usecase?.renameValue}
+                invalid={!!usecase?.renameValidation}
+                onChange={(e) => usecase?.setRenameValue(e.target.value)}
+              />
+              {!!usecase?.renameValidation && (
+                <p className='text-xs text-error-500 mt-0.5'>
+                  {usecase?.renameValidation}
+                </p>
+              )}
+            </ModalBody>
+            <ModalFooter className='flex gap-3 justify-between'>
+              <Button className='flex-1' onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                className='flex-1'
+                colorScheme='primary'
+                isDisabled={!!usecase?.renameValidation}
+                onClick={() =>
+                  usecase?.execute({ onSuccess: () => onOpenChange(false) })
+                }
+              >
+                Rename
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        </ModalPortal>
       </Modal>
     );
   },

--- a/src/domain/usecases/document/document-rename-inline.usecase.ts
+++ b/src/domain/usecases/document/document-rename-inline.usecase.ts
@@ -1,0 +1,69 @@
+import { Tracer } from '@infra/tracer';
+import { action, observable } from 'mobx';
+import { inject } from '@infra/container';
+import { Document } from '@store/Documents/Document.dto';
+import { DocumentsStore } from '@store/Documents/Documents.store';
+import { DocumentService } from '@domain/services/document/document.service';
+
+export class DocumentRenameInlineUsecase {
+  @inject(DocumentService) private service!: DocumentService;
+
+  @observable private accessor document: Document | null = null;
+
+  constructor(private store: DocumentsStore) {}
+
+  @action
+  setDocumentName = (value: string) => {
+    const span = Tracer.span('DocumentRenameInlineUsecase.setDocumentName');
+
+    if (!this.document) {
+      console.error(
+        'DocumentRenameInlineUsecase.execute: document must not be null',
+      );
+
+      span.end();
+
+      return;
+    }
+
+    this.document.draft();
+    this.document.value.name = value;
+    this.document.commit({ syncOnly: true });
+
+    span.end();
+  };
+
+  @action
+  init = (docId: string) => {
+    const span = Tracer.span('DocumentRenameInlineUsecase.init');
+
+    this.document = this.store.getById(docId)!;
+    span.end();
+  };
+
+  execute = async () => {
+    const span = Tracer.span('DocumentRenameInlineUsecase.execute');
+
+    if (!this.document) {
+      console.error(
+        'DocumentRenameInlineUsecase.execute: document must not be null',
+      );
+
+      span.end();
+
+      return;
+    }
+
+    const [_, err] = await this.service.updateDocument(this.document);
+
+    if (err) {
+      console.error('DocumentRenameInlineUsecase.execute', err);
+
+      span.end();
+
+      return;
+    }
+
+    span.end();
+  };
+}

--- a/src/ui/presentation/HtmlContentRenderer/HtmlContentRenderer.tsx
+++ b/src/ui/presentation/HtmlContentRenderer/HtmlContentRenderer.tsx
@@ -72,6 +72,12 @@ export const HtmlContentRenderer = ({
         if (domNode.attribs) {
           newAttribs = Object.keys(domNode.attribs).reduce(
             (result: Record<string, string>, key) => {
+              if (key === 'class') {
+                result['className'] = domNode.attribs[key];
+
+                return result;
+              }
+
               if (key !== 'style') {
                 result[key] = domNode.attribs[key];
               }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces modal-based document renaming with inline renaming in `DocumentEditor` and updates pre-commit script to run unit tests.
> 
>   - **Behavior**:
>     - Replaces modal-based document renaming with inline renaming in `DocumentEditor.tsx` using `DocumentRenameInlineUsecase`.
>     - Removes `DocumentRenameModal` usage from `DocumentEditor.tsx`.
>     - Adds `DocumentRenameInlineUsecase` to handle inline renaming logic.
>   - **Pre-commit**:
>     - Updates `scripts/pre-commit` to run unit tests with `npm run test:unit -- run --silent`.
>   - **HtmlContentRenderer**:
>     - Updates `HtmlContentRenderer.tsx` to convert `class` attributes to `className`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for f53116ba65241136aafb518ef6ea324c46c92726. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->