### PR TITLE
Contract changes

### DIFF
--- a/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/ContractDetails/ContractDetailsModal.tsx
+++ b/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractBillingDetailsModal/components/ContractDetails/ContractDetailsModal.tsx
@@ -11,6 +11,7 @@ import { cn } from '@ui/utils/cn';
 import { Input } from '@ui/form/Input';
 import { Button } from '@ui/form/Button/Button';
 import { useStore } from '@shared/hooks/useStore';
+import { useModKey } from '@shared/hooks/useModKey';
 import { ModalFooter, ModalHeader } from '@ui/overlay/Modal/Modal';
 import { calculateMaxArr } from '@organization/components/Tabs/panels/AccountPanel/utils';
 import {
@@ -293,6 +294,8 @@ export const ContractDetailsModal = observer(
       }
     }, [canAllowPayWithBankTransfer]);
 
+    useModKey('Enter', handleApplyChanges);
+
     return (
       <>
         <motion.div
@@ -320,6 +323,11 @@ export const ContractDetailsModal = observer(
               placeholder='Add contract name'
               onFocus={(e) => e.target.select()}
               value={contractStore?.tempValue?.contractName}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  handleCloseModal();
+                }
+              }}
               className='font-semibold text-base no-border-bottom hover:border-none focus:border-none max-h-6 min-h-0 w-full overflow-hidden overflow-ellipsis truncate'
               onChange={(e) =>
                 contractStore?.updateTemp((prev) => ({

--- a/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
+++ b/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/ContractCard.tsx
@@ -4,7 +4,6 @@ import { observer } from 'mobx-react-lite';
 import { differenceInMilliseconds } from 'date-fns';
 import { ContractStore } from '@store/Contracts/Contract.store.ts';
 
-import { Input } from '@ui/form/Input';
 import { useStore } from '@shared/hooks/useStore';
 import { Divider } from '@ui/presentation/Divider/Divider';
 import { AgentType, ContractStatus } from '@graphql/types';
@@ -96,31 +95,16 @@ export const ContractCard = observer(
           className='p-0 w-full flex flex-col'
           onClick={() => (!isExpanded ? setIsExpanded(true) : null)}
         >
-          <article
+          <div
             data-test='contract-card-header'
             className='flex justify-between flex-1 w-full'
           >
-            <Input
-              name='contractName'
-              value={contract?.contractName}
-              placeholder='Add contract name'
-              onFocus={(e) => e.target.select()}
-              onBlur={(e) => {
-                contractStore?.updateContractName(e.target.value);
-              }}
-              className='font-medium hover:border-none focus:border-none max-h-6 min-h-0 w-full overflow-hidden overflow-ellipsis border-0'
-              onChange={(e) => {
-                contractStore?.update(
-                  (prev) => ({
-                    ...prev,
-                    contractName: e.target.value,
-                  }),
-                  {
-                    mutate: false,
-                  },
-                );
-              }}
-            />
+            <p
+              className='font-medium text-[16px]'
+              onClick={handleOpenContractDetails}
+            >
+              {contract?.contractName}
+            </p>
 
             <ContractCardActions
               status={contract?.contractStatus}
@@ -133,7 +117,7 @@ export const ContractCard = observer(
                 'Unnamed'
               }
             />
-          </article>
+          </div>
 
           <div
             tabIndex={1}

--- a/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/UpcomingInvoices/UpcomingInvoices.tsx
+++ b/src/routes/organization/src/components/Tabs/panels/AccountPanel/Contract/UpcomingInvoices/UpcomingInvoices.tsx
@@ -77,6 +77,19 @@ export const UpcomingInvoices = observer(
     }, [getIsPaused]);
 
     const getActionButton = () => {
+      if (!contract.value?.billingEnabled) {
+        return (
+          <Button
+            size='xxs'
+            colorScheme='grayModern'
+            className='ml-2 font-normal rounded'
+            onClick={onOpenServiceLineItemsModal}
+          >
+            Enable invoicing
+          </Button>
+        );
+      }
+
       if (
         !contract.value?.billingDetails?.billingEmail &&
         !contract.value?.billingDetails?.organizationLegalName
@@ -104,19 +117,6 @@ export const UpcomingInvoices = observer(
             leftIcon={<Edit03 className='size-3' />}
           >
             Add email
-          </Button>
-        );
-      }
-
-      if (!contract.value?.billingEnabled) {
-        return (
-          <Button
-            size='xxs'
-            colorScheme='grayModern'
-            className='ml-2 font-normal rounded'
-            onClick={onOpenServiceLineItemsModal}
-          >
-            Enable invoicing
           </Button>
         );
       }

--- a/src/routes/organization/src/components/Tabs/panels/AccountPanel/context/ContractModalsContext.tsx
+++ b/src/routes/organization/src/components/Tabs/panels/AccountPanel/context/ContractModalsContext.tsx
@@ -7,6 +7,8 @@ import {
   PropsWithChildren,
 } from 'react';
 
+import { useKey } from 'rooks';
+
 import { useDisclosure } from '@ui/utils/hooks/useDisclosure';
 import { useTimelineEventPreviewMethodsContext } from '@organization/components/Timeline/shared/TimelineEventPreview/context/TimelineEventPreviewContext.tsx';
 
@@ -52,6 +54,8 @@ export const ContractModalsContextProvider = ({
   } = useDisclosure({
     id: `edit-contract-modal-${id}`,
   });
+
+  useKey('Escape', onEditModalClose);
 
   const handleOpen = () => {
     onEditModalOpen();


### PR DESCRIPTION
added keybinding for close + submit contractEdit, remove ability to rename contract from card + for nextInvoice first step to be checked is if billingEnabled
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added keybindings for contract modals, removed inline contract renaming, and updated billing logic in contract components.
> 
>   - **Keybindings**:
>     - Added `Enter` keybinding to `ContractDetailsModal.tsx` to submit contract edits.
>     - Added `Escape` keybinding to `ContractDetailsModal.tsx` and `ContractModalsContext.tsx` to close modals.
>   - **Contract Editing**:
>     - Removed ability to rename contract directly from `ContractCard.tsx`.
>     - Contract name editing now requires opening the contract details modal.
>   - **Billing Logic**:
>     - Updated `UpcomingInvoices.tsx` to check `billingEnabled` before other billing details.
>     - Adjusted action buttons in `UpcomingInvoices.tsx` based on billing status and details.
>   - **Misc**:
>     - Removed unused `Input` import from `ContractCard.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 01023d94c350c439e94b3add597ee75f208d496c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->