### PR TITLE
patch: add zIndex to toolbarPlugin

### DIFF
--- a/src/ui/form/Editor/plugins/FloatingTextFormatToolbarPlugin.tsx
+++ b/src/ui/form/Editor/plugins/FloatingTextFormatToolbarPlugin.tsx
@@ -189,7 +189,7 @@ export function FloatingMenu({ editor }: FloatingMenuComponentProps) {
   return (
     <div
       ref={menuRef}
-      className='flex items-center justify-between bg-grayModern-700 text-grayModern-25 border-[1px] border-grayModern-200 rounded-md p-1 gap-1'
+      className='flex items-center justify-between bg-grayModern-700 text-grayModern-25 border-[1px] border-grayModern-200 rounded-md p-1 gap-1 '
     >
       <>
         <Tooltip label='Bold: ⌘ + B'>
@@ -440,6 +440,7 @@ export function FloatingMenuPlugin({
       aria-hidden={!show}
       style={{
         position: 'absolute',
+        zIndex: 9999,
         top: coords?.y,
         left: coords?.x,
         visibility: show ? 'visible' : 'hidden',

--- a/src/ui/form/Editor/plugins/FloatingTextFormatToolbarPlugin.tsx
+++ b/src/ui/form/Editor/plugins/FloatingTextFormatToolbarPlugin.tsx
@@ -189,7 +189,7 @@ export function FloatingMenu({ editor }: FloatingMenuComponentProps) {
   return (
     <div
       ref={menuRef}
-      className='flex items-center justify-between bg-grayModern-700 text-grayModern-25 border-[1px] border-grayModern-200 rounded-md p-1 gap-1 '
+      className='flex items-center justify-between bg-grayModern-700 text-grayModern-25 border-[1px] border-grayModern-200 rounded-md p-1 gap-1'
     >
       <>
         <Tooltip label='Bold: ⌘ + B'>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `zIndex: 9999` to `FloatingMenuPlugin` in `FloatingTextFormatToolbarPlugin.tsx` to ensure it appears above other elements.
> 
>   - **UI Enhancement**:
>     - Adds `zIndex: 9999` to the `style` of the `FloatingMenuPlugin` in `FloatingTextFormatToolbarPlugin.tsx` to ensure it appears above other elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 3124b087041f22f3e8f2eafc05cd9133a5690009. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->