### PR TITLE
remove parentComp filter + fix users presence

### DIFF
--- a/src/routes/finder/src/components/Columns/organizations/filterTypes.tsx
+++ b/src/routes/finder/src/components/Columns/organizations/filterTypes.tsx
@@ -460,20 +460,6 @@ export const getFilterTypes = (store?: RootStore) => {
         },
       ],
     },
-    [ColumnViewType.OrganizationsParentOrganization]: {
-      filterType: 'text',
-      filterName: 'Parent company',
-      filterAccesor: ColumnViewType.OrganizationsParentOrganization,
-      filterOperators: [
-        ComparisonOperator.Contains,
-        ComparisonOperator.NotContains,
-        ComparisonOperator.IsEmpty,
-        ComparisonOperator.IsNotEmpty,
-      ],
-      icon: (
-        <Globe01 className='group-hover:text-grayModern-700 text-grayModern-500 mb-0.5' />
-      ),
-    },
   };
 
   return filterTypes;

--- a/src/routes/src/components/UserHexagon/UserHexagon.tsx
+++ b/src/routes/src/components/UserHexagon/UserHexagon.tsx
@@ -1,9 +1,11 @@
+import { useNavigate } from 'react-router-dom';
+
 import { observer } from 'mobx-react-lite';
 
+import { cn } from '@ui/utils/cn';
 import { Image } from '@ui/media/Image/Image';
 import { useStore } from '@shared/hooks/useStore';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
-
 interface UserHexagonProps {
   id: string;
   name: string;
@@ -14,17 +16,39 @@ interface UserHexagonProps {
 export const UserHexagon = observer(
   ({ name, isCurrent, color, id }: UserHexagonProps) => {
     const store = useStore();
+
     const url = store.users.getById(id)?.value?.profilePhotoUrl;
 
-    if (url) {
-      return <ClippedImage name={name} color={color} url={url ?? ''} />;
+    const navigate = useNavigate();
+
+    if (url && url?.length > 0) {
+      return (
+        <ClippedImage
+          name={name}
+          color={color}
+          url={url ?? ''}
+          isCurrent={isCurrent ?? false}
+        />
+      );
     }
 
     return (
       <Tooltip hasArrow label={name}>
-        <div className='flex relative size-7 items-center justify-center cursor-default'>
+        <div
+          className={cn(
+            'flex relative size-7 items-center justify-center cursor-default',
+            isCurrent && 'cursor-pointer',
+          )}
+        >
           <p
-            className='text-sm z-[2] rounded-full size-7 flex items-center justify-center'
+            className={cn(
+              'text-sm z-[2] rounded-full size-7 flex items-center justify-center',
+            )}
+            onClick={() => {
+              if (isCurrent) {
+                navigate(`/settings/?tab=profile`);
+              }
+            }}
             style={{
               color: isCurrent ? 'white' : color,
               backgroundColor: isCurrent ? color : 'white',
@@ -44,14 +68,28 @@ const ClippedImage = ({
   name,
   color,
   url,
+  isCurrent,
 }: {
   url: string;
   name: string;
   color: string;
+  isCurrent: boolean;
 }) => {
+  const navigate = useNavigate();
+
   return (
     <Tooltip hasArrow label={name}>
-      <div className='flex size-7 items-center justify-center rounded-full relative'>
+      <div
+        onClick={() => {
+          if (isCurrent) {
+            navigate(`/settings/?tab=profile`);
+          }
+        }}
+        className={cn(
+          'flex size-7 items-center justify-center rounded-full relative cursor-default',
+          isCurrent && 'cursor-pointer',
+        )}
+      >
         <Image
           src={url}
           aria-label={name}

--- a/src/store/Users/User.dto.ts
+++ b/src/store/Users/User.dto.ts
@@ -22,7 +22,7 @@ export class User extends Entity<UserDatum> {
 
   @computed
   get name() {
-    return this.value.name || `${this.value.firstName} ${this.value.lastName}`;
+    return this.value.name;
   }
 
   @computed


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove parent company filter and enhance user presence handling in `UserHexagon` component.
> 
>   - **Filter Removal**:
>     - Removed `OrganizationsParentOrganization` filter from `filterTypes.tsx`.
>   - **User Presence**:
>     - Added `useNavigate` to `UserHexagon.tsx` for navigation on user click.
>     - Updated `UserHexagon` to handle `isCurrent` state, enabling profile navigation.
>     - Modified `getInitials()` to handle user initials display.
>   - **User Model**:
>     - Removed fallback to first and last name in `name` getter in `User.dto.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for c6ee735910c6b6674f1eaaa635492c9a46bd13b1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->