### PR TITLE
fix nylas

### DIFF
--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -48,7 +48,7 @@ export const RootRoute: RouteObject = {
             schedulerPreviewLink={`${window.location.origin}/book?config_id={config.id}`}
             nylasSessionsConfig={{
               clientId: '6ff9c91b-3b9d-4980-ace1-949313d0a475', // Replace with your Nylas client ID from the previous
-              redirectUri: `http://localhost:5173/scheduler-editor`,
+              redirectUri: `https://app.customeros.ai/scheduler-editor`,
               domain: 'https://api.eu.nylas.com/v3', // or 'https://api.eu.nylas.com/v3' for EU data center
               hosted: false,
               accessType: 'offline',


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `redirectUri` in `RootRoute` for Nylas Scheduler Editor in `root.tsx`.
> 
>   - **Behavior**:
>     - Update `redirectUri` in `RootRoute` in `root.tsx` from `http://localhost:5173/scheduler-editor` to `https://app.customeros.ai/scheduler-editor` for Nylas Scheduler Editor.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for cdfd9caf0fe8de8bde49c10fbaa640911d950224. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->