### PR TITLE
Update gcalendar scopes

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -446,7 +446,7 @@ async function createServer() {
       'profile',
       'https://www.googleapis.com/auth/gmail.readonly',
       'https://www.googleapis.com/auth/gmail.send',
-      'https://www.googleapis.com/auth/calendar.readonly',
+      'https://www.googleapis.com/auth/calendar',
       'https://mail.google.com/',
     ];
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Google Calendar OAuth2 scope to full access in `middleware/index.js`.
> 
>   - **Behavior**:
>     - Update Google Calendar scope from `https://www.googleapis.com/auth/calendar.readonly` to `https://www.googleapis.com/auth/calendar` in `createServer()` function in `middleware/index.js`.
>   - **OAuth**:
>     - Affects OAuth2 authentication process for Google services, allowing full calendar access instead of read-only.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 03916828c741432bc3856e1db035ae6ab7508881. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->