### PR TITLE
patch: bump updatedAt on every property set for organization entity

### DIFF
--- a/src/domain/aggregates/organization.aggregate.ts
+++ b/src/domain/aggregates/organization.aggregate.ts
@@ -89,10 +89,12 @@ export class OrganizationAggregate {
     if (!record) return;
 
     this.organization.owner = record.value;
+    this.organization.bumpUpdatedAt();
   };
 
   clearOwner = () => {
     this.organization.owner = null;
+    this.organization.bumpUpdatedAt();
   };
 
   addTag = (id: string) => {
@@ -111,16 +113,19 @@ export class OrganizationAggregate {
     }
 
     this.organization.tags.push(tag.value);
+    this.organization.bumpUpdatedAt();
   };
 
   deleteTag = (id: string) => {
     const index = this.organization.tags.findIndex((t) => t.metadata.id === id);
 
     this.organization.tags.splice(index, 1);
+    this.organization.bumpUpdatedAt();
   };
 
   clearTags = () => {
     this.organization.tags = [];
+    this.organization.bumpUpdatedAt();
   };
 
   mergeOrganizations = (organizations: Organization[]) => {
@@ -129,5 +134,6 @@ export class OrganizationAggregate {
 
   addContact = (contact: Contact) => {
     this.organization.contacts.push(contact?.id);
+    this.organization.bumpUpdatedAt();
   };
 }

--- a/src/domain/entities/organization.entity.ts
+++ b/src/domain/entities/organization.entity.ts
@@ -115,6 +115,7 @@ export class Organization implements OrganizationDatum {
 
   flagIncorrectIndustry = () => {
     this.wrongIndustry = true;
+    this.bumpUpdatedAt();
   };
 
   setRenewalAdjustedRate = (
@@ -155,46 +156,57 @@ export class Organization implements OrganizationDatum {
         () => OrganizationStage.Target,
       )
       .otherwise(() => undefined);
+
+    this.bumpUpdatedAt();
   };
 
   setStage = (stage: OrganizationStage) => {
     this.stage = stage;
+    this.bumpUpdatedAt();
   };
 
   removeStage = () => {
     this.stage = null;
+    this.bumpUpdatedAt();
   };
 
   setNotes = (notes: string) => {
     this.notes = notes;
+    this.bumpUpdatedAt();
   };
 
   addSocial = (url: string) => {
     this.socialMedia.push(Social.create({ url }));
+    this.bumpUpdatedAt();
   };
 
   deleteSocial = (id: string) => {
     const index = this.socialMedia.findIndex((s) => s.id === id);
 
     this.socialMedia.splice(index, 1);
+    this.bumpUpdatedAt();
   };
 
   revertSocial = (social: Social) => {
     this.socialMedia.push(social);
+    this.bumpUpdatedAt();
   };
 
   addDomain = (payload: Partial<Domain>) => {
     this.domainsDetails.push(Domain.create(payload));
+    this.bumpUpdatedAt();
   };
 
   deleteDomain = (domain: string) => {
     const index = this.domainsDetails.findIndex((d) => d.domain !== domain);
 
     this.domainsDetails.splice(index, 1);
+    this.bumpUpdatedAt();
   };
 
   addContract = (contractId: string) => {
     this.contracts.unshift(contractId);
+    this.bumpUpdatedAt();
   };
 
   deleteContract = (contractId: string) => {
@@ -203,6 +215,8 @@ export class Organization implements OrganizationDatum {
     if (index > -1) {
       this.contracts.splice(index, 1);
     }
+
+    this.bumpUpdatedAt();
   };
 
   deleteContact = (contactId: string) => {
@@ -211,10 +225,13 @@ export class Organization implements OrganizationDatum {
     if (index > -1) {
       this.contacts.splice(index, 1);
     }
+
+    this.bumpUpdatedAt();
   };
 
   setRenewalLikelihood = (likelihood: OpportunityRenewalLikelihood) => {
     this.renewalSummaryRenewalLikelihood = likelihood;
+    this.bumpUpdatedAt();
   };
 
   toSaveInput = (): OrganizationSaveInput => ({
@@ -259,4 +276,8 @@ export class Organization implements OrganizationDatum {
     slackChannelId: this.slackChannelId,
     lastFundingRound: this.lastFundingRound,
   });
+
+  bumpUpdatedAt = () => {
+    this.updatedAt = new Date().toISOString();
+  };
 }

--- a/src/domain/services/organization/organizations.service.ts
+++ b/src/domain/services/organization/organizations.service.ts
@@ -1,3 +1,4 @@
+import { Tracer } from '@infra/tracer';
 import { Logger } from '@/infra/logger';
 import { RootStore } from '@/store/root';
 import { Social } from '@/domain/objects';
@@ -266,6 +267,10 @@ export class OrganizationService {
   }
 
   public async addTag(organization: Organization, tag: TagStore) {
+    const span = Tracer.span('OrganizationService.addTag', {
+      organizationId: organization.id,
+      tag: tag.value,
+    });
     const organizationAggregate = new OrganizationAggregate(
       organization,
       this.root,
@@ -290,7 +295,10 @@ export class OrganizationService {
 
     if (res) {
       this.organizationStore.sync(organization);
+      this.utilService.toastSuccess('Tag added', 'add-tag');
     }
+
+    span.end();
 
     return [res, err];
   }

--- a/src/domain/services/util/util.service.ts
+++ b/src/domain/services/util/util.service.ts
@@ -6,11 +6,11 @@ import { toastError, toastSuccess } from '@ui/presentation/Toast';
 export class UtilService {
   constructor() {}
 
-  toastSuccess(text: string) {
-    toastSuccess(text, crypto.randomUUID());
+  toastSuccess(text: string, id?: string) {
+    toastSuccess(text, id ?? crypto.randomUUID());
   }
 
-  toastError(text: string) {
-    toastError(text, crypto.randomUUID());
+  toastError(text: string, id?: string) {
+    toastError(text, id ?? crypto.randomUUID());
   }
 }

--- a/src/domain/stores/__tests__/organization.store.test.ts
+++ b/src/domain/stores/__tests__/organization.store.test.ts
@@ -74,6 +74,7 @@ vi.mock('@/domain/stores/session.store', () => {
   return {
     sessionStore: {
       isAuthenticated: true,
+      tenant: 'test',
       user: {
         id: 1,
         username: 'test-user',

--- a/src/domain/stores/organization.store.ts
+++ b/src/domain/stores/organization.store.ts
@@ -19,10 +19,13 @@ const repository = new OrganizationRepository();
 let channel: Channel | null = null;
 
 const getChannel = () => {
-  if (!channel && transport.socket) {
-    channel = transport.socket?.channel('OrganizationStore:PureThePhantom', {
-      ...transport.channelMeta,
-    });
+  if (!channel && transport.socket && sessionStore.tenant) {
+    channel = transport.socket?.channel(
+      `OrganizationStore:${sessionStore.tenant}`,
+      {
+        ...transport.channelMeta,
+      },
+    );
   }
 
   return channel;

--- a/src/domain/stores/organization.store.ts
+++ b/src/domain/stores/organization.store.ts
@@ -4,9 +4,14 @@ import { Transport } from '@/infra/transport';
 import { Organization } from '@/domain/entities';
 import { reaction, runInAction, ObservableMap } from 'mobx';
 import { sessionStore } from '@/domain/stores/session.store';
-import { FetchPolicy, applyPolicies, RealtimePolicy } from '@/lib/policy';
 import { OrganizationRepository } from '@/infra/repositories/core/organization';
 import { OrganizationViews } from '@/domain/views/organization/organization.views';
+import {
+  FetchPolicy,
+  applyPolicies,
+  RealtimePolicy,
+  PolicyEnhancedStore,
+} from '@/lib/policy';
 
 const transport = Transport.getInstance('core');
 const repository = new OrganizationRepository();
@@ -29,10 +34,14 @@ const store = new Store<Organization>({
   mutator: runInAction,
 });
 
-const fetchPolicy = new FetchPolicy(async ({ key }) => {
-  const res = await repository.getOrganizationsByIds({ ids: [key as string] });
+const fetchOrganization = async (id: string) => {
+  const res = await repository.getOrganizationsByIds({ ids: [id] });
 
   return new Organization(res.ui_organizations?.[0]);
+};
+
+const fetchPolicy = new FetchPolicy(async ({ key }) => {
+  return await fetchOrganization(key as string);
 });
 
 const realtimePolicy = new RealtimePolicy<Organization>(getChannel, {
@@ -42,15 +51,26 @@ const realtimePolicy = new RealtimePolicy<Organization>(getChannel, {
       fireImmediately: true,
     }),
   fetchOnInvalidate: async (id) => {
-    const res = await repository.getOrganizationsByIds({
-      ids: [id as string],
-    });
-
-    return new Organization(res.ui_organizations?.[0]);
+    return await fetchOrganization(id as string);
   },
   onEvent: (p) => {
     if (p.type === 'store:set') {
-      OrganizationViews.revalidate(new Organization(p.value));
+      const datum = !p.value
+        ? { id: p.key, updatedAt: new Date().toISOString() }
+        : p.value;
+
+      if (!p.value) {
+        // receive create events from system
+        fetchOrganization(p.key).then((o) => {
+          (store as PolicyEnhancedStore).suspendSync(() => {
+            store.set(p.key, o);
+          });
+
+          OrganizationViews.revalidate(new Organization(datum));
+        });
+      } else {
+        OrganizationViews.revalidate(new Organization(datum));
+      }
     }
 
     if (p.type === 'store:delete') {

--- a/src/domain/stores/session.store.ts
+++ b/src/domain/stores/session.store.ts
@@ -2,6 +2,7 @@ import { makeAutoObservable } from 'mobx';
 
 class SessionStore {
   isAuthenticated = false;
+  tenant = '';
 
   constructor() {
     makeAutoObservable(this);
@@ -9,6 +10,10 @@ class SessionStore {
 
   setIsAuthenthicated = () => {
     this.isAuthenticated = true;
+  };
+
+  setTenant = (tenant: string) => {
+    this.tenant = tenant;
   };
 }
 

--- a/src/domain/usecases/command-menu/organization/edit-organization-tag.usecase.ts
+++ b/src/domain/usecases/command-menu/organization/edit-organization-tag.usecase.ts
@@ -120,6 +120,10 @@ export class EditOrganizationTagUsecase {
   };
 
   private handleSingleOrganizationTag = (tag: TagStore) => {
+    const span = Tracer.span(
+      'EditOrganizationTagUsecase.handleSingleOrganizationTag',
+      tag.value,
+    );
     const hasTag = this.organization?.tags?.some(
       (t) => t.metadata.id === tag.id,
     );
@@ -130,6 +134,8 @@ export class EditOrganizationTagUsecase {
     } else {
       this.organizationService.addTag(this.organization!, tag);
     }
+
+    span.end();
   };
 
   private handleMultipleOrganizationsTags = (tag: TagStore) => {

--- a/src/lib/policy/apply.ts
+++ b/src/lib/policy/apply.ts
@@ -57,3 +57,5 @@ export function applyPolicies<
     },
   });
 }
+
+export type PolicyEnhancedStore = ReturnType<typeof applyPolicies>;

--- a/src/lib/policy/realtime-policy.ts
+++ b/src/lib/policy/realtime-policy.ts
@@ -196,12 +196,14 @@ export class RealtimePolicy<T> extends Policy<T> {
   }
 
   suspendSync(fn: () => void) {
+    const wasSuspended = this.isSyncSuspended;
+
     this.isSyncSuspended = true;
 
     try {
       fn();
     } finally {
-      this.isSyncSuspended = false;
+      this.isSyncSuspended = wasSuspended;
     }
   }
 

--- a/src/lib/store/store.ts
+++ b/src/lib/store/store.ts
@@ -81,8 +81,6 @@ export class Store<T> {
       return;
     }
 
-    this.mutate(() => {
-      this.cache.set(entity[this.indexBy!] as string | number, entity);
-    });
+    this.set(entity[this.indexBy!] as string | number, entity);
   }
 }

--- a/src/routes/finder/src/components/FinderTable/FinderTable.tsx
+++ b/src/routes/finder/src/components/FinderTable/FinderTable.tsx
@@ -423,7 +423,6 @@ export const FinderTable = observer(() => {
         rowHeight={rowHeight}
         id={tableViewDef?.id}
         totalItems={totalItems}
-        getRowId={(row) => row.id}
         canFetchMore={canFetchMore}
         enableColumnResizing={true}
         onSortingChange={handleSortChange}
@@ -433,6 +432,9 @@ export const FinderTable = observer(() => {
         dataTest={`finder-table-${tableType}`}
         enableRowSelection={enableRowSelection}
         tableType={tableViewDef?.value?.tableId}
+        getRowId={(row) => {
+          return row.id;
+        }}
         // isLoading={store.organizations.isLoading}
         enableKeyboardShortcuts={
           !isEditing && !isFiltering && !isCommandMenuPrompted

--- a/src/store/Session/Session.store.ts
+++ b/src/store/Session/Session.store.ts
@@ -5,6 +5,7 @@ import { match } from 'ts-pattern';
 import { AxiosError } from 'axios';
 import { Persister } from '@store/persister';
 import { Transport } from '@infra/transport.ts';
+import { sessionStore } from '@/domain/stores/session.store';
 import { toJS, autorun, runInAction, makeAutoObservable } from 'mobx';
 
 // temporary - will be removed once we drop react-query and getGraphQLClient
@@ -91,6 +92,8 @@ export class SessionStore {
           'X-Openline-TENANT': this.value.tenant ?? '',
           'X-Openline-USERNAME': this.value.profile.email ?? '',
         };
+
+        sessionStore.setTenant(this.value.tenant);
 
         this.transport.setHeaders(headers);
         Transport.getInstance('mailstack').setHeaders(headers);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `updatedAt` timestamp on property changes for `Organization` entity and add tracing and session management improvements.
> 
>   - **Behavior**:
>     - Add `bumpUpdatedAt()` to `setOwner`, `clearOwner`, `addTag`, `deleteTag`, `clearTags`, `addContact` in `organization.aggregate.ts`.
>     - Add `bumpUpdatedAt()` to `flagIncorrectIndustry`, `setRenewalAdjustedRate`, `setStage`, `removeStage`, `setNotes`, `addSocial`, `deleteSocial`, `revertSocial`, `addDomain`, `deleteDomain`, `addContract`, `deleteContract`, `deleteContact`, `setRenewalLikelihood` in `organization.entity.ts`.
>   - **Logging**:
>     - Add tracing spans in `addTag` in `organizations.service.ts` and `handleSingleOrganizationTag` in `edit-organization-tag.usecase.ts`.
>   - **Session Management**:
>     - Add `tenant` property to `sessionStore` in `session.store.ts` and update it in `Session.store.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for d1e00dec2e5520137f81b26e8b0b2331f804a56d. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->