### PR TITLE
fix redirect url

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -86,7 +86,7 @@ const googleOauthEmailClient = new google.auth.OAuth2(
 const googleOauthCalendarClient = new google.auth.OAuth2(
   process.env.GMAIL_CLIENT_ID,
   process.env.GMAIL_CLIENT_SECRET,
-  'http://localhost:5174/callback/google-auth-calendar-grant',
+  `${process.env.VITE_MIDDLEWARE_API_URL}/callback/google-auth-calendar-grant`,
 );
 
 async function customerOsSignIn(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update redirect URL for `googleOauthCalendarClient` in `middleware/index.js` to use environment variable for base URL.
> 
>   - **Behavior**:
>     - Update redirect URL for `googleOauthCalendarClient` in `middleware/index.js` to use `process.env.VITE_MIDDLEWARE_API_URL` instead of hardcoded `http://localhost:5174`.
>     - Affects OAuth flow for Google Calendar access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 2e5b8e23e0993a40e5d23b3616b3dbc1a92f3fd1. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->