### PR TITLE
fix: remove scrollIntoView at clickOutside

### DIFF
--- a/src/ui/form/Editor/plugins/FloatingTextFormatToolbarPlugin.tsx
+++ b/src/ui/form/Editor/plugins/FloatingTextFormatToolbarPlugin.tsx
@@ -10,14 +10,12 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import {
   LexicalNode,
   $getSelection,
-  $setSelection,
   $isRangeSelection,
   KEY_ESCAPE_COMMAND,
   FORMAT_TEXT_COMMAND,
   KEY_MODIFIER_COMMAND,
   $createParagraphNode,
   COMMAND_PRIORITY_HIGH,
-  $createRangeSelection,
   COMMAND_PRIORITY_NORMAL,
   COMMAND_PRIORITY_NORMAL as NORMAL_PRIORITY,
   SELECTION_CHANGE_COMMAND as ON_SELECTION_CHANGE,
@@ -339,25 +337,6 @@ export function FloatingMenuPlugin({
       if (ref.current && !ref.current?.contains(event.target as Node)) {
         editor.update(() => {
           setCoords(undefined);
-
-          const currentSelection = $getSelection();
-
-          if ($isRangeSelection(currentSelection)) {
-            const newSelection = $createRangeSelection();
-
-            newSelection.anchor.set(
-              currentSelection.focus.key,
-              currentSelection.focus.offset,
-              currentSelection.focus.type,
-            );
-            newSelection.focus.set(
-              currentSelection.focus.key,
-              currentSelection.focus.offset,
-              currentSelection.focus.type,
-            );
-            newSelection.dirty = true;
-            $setSelection(newSelection);
-          }
         });
       }
     },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes unnecessary selection handling logic when clicking outside the floating menu in `FloatingTextFormatToolbarPlugin.tsx`.
> 
>   - **Behavior**:
>     - Removes `scrollIntoView` logic when clicking outside the floating menu in `FloatingTextFormatToolbarPlugin.tsx`.
>     - Simplifies selection handling by removing `$createRangeSelection` and `$setSelection` calls.
>   - **Code Cleanup**:
>     - Deletes unused imports `$setSelection` and `$createRangeSelection` from `FloatingTextFormatToolbarPlugin.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 0096a7c579103da6b582f3b00b984440fbf88681. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->