### PR TITLE
implement free acount page

### DIFF
--- a/src/routes/auth/failure/page.tsx
+++ b/src/routes/auth/failure/page.tsx
@@ -5,6 +5,8 @@ import { observer } from 'mobx-react-lite';
 import { Button } from '@ui/form/Button/Button';
 import { useStore } from '@shared/hooks/useStore';
 
+import CustomerOsLogo from '../signin/CustomerOS-logo.png';
+
 export const FailurePage = observer(() => {
   const store = useStore();
   const navigate = useNavigate();
@@ -15,6 +17,43 @@ export const FailurePage = observer(() => {
     store.session.clearSession();
     navigate('/auth/signin');
   };
+
+  if (message === 'PERSONAL_EMAIL_DOMAIN') {
+    return (
+      <div className='h-screen w-screen flex animate-fadeIn overflow-hidden max-h-screen max-w-screen'>
+        <div className='flex-1 items-center h-screen overflow-hidden'>
+          <div className='h-full flex items-center justify-center relative'>
+            <div className='relative flex flex-col items-center justify-center w-[450px] h-full px-6 pb-6 bg-white'>
+              <div className='h-full flex items-center justify-center relative '>
+                <div className='flex flex-col items-center w-[360px]'>
+                  <img
+                    width={264}
+                    height={264}
+                    alt='CustomerOS'
+                    src={CustomerOsLogo}
+                  />
+                  <h2 className='text-grayModern-900 leading-9 font-bold text-3xl py-3 mt-[-40px] text-center'>
+                    Sign in with your work email
+                  </h2>
+                  <p className='mb-2 text-grayModern-500 text-center'>
+                    Looks like you’re trying to sign in with a personal email
+                    like Gmail or Yahoo.
+                  </p>
+                  <p className='mb-4 text-grayModern-500 text-center'>
+                    To sign in, you’ll need to use your work or company email
+                    instead.
+                  </p>
+                  <Button className='w-full' onClick={handleClick}>
+                    Go back
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className='flex items-center justify-center h-screen w-screen'>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a new page in `FailurePage` to handle personal email domain sign-in failures with a message and navigation option.
> 
>   - **Behavior**:
>     - Adds handling for `PERSONAL_EMAIL_DOMAIN` message in `FailurePage` in `page.tsx`.
>     - Displays a message instructing users to sign in with a work email instead of a personal email.
>     - Provides a "Go back" button to navigate back to the sign-in page.
>   - **Assets**:
>     - Imports `CustomerOS-logo.png` for display on the failure page.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 96e73ad9e98b83b041724ff4b5f0894a10044e96. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->