### PR TITLE
added back table actions for flows

### DIFF
--- a/src/routes/finder/src/components/Actions/FlowsActions.tsx
+++ b/src/routes/finder/src/components/Actions/FlowsActions.tsx
@@ -16,9 +16,6 @@ interface TableActionsProps {
   enableKeyboardShortcuts?: boolean;
 }
 
-/**
- * @deprecated - TODO: To be removed after we conclude what we do with flows in agents
- */
 export const FlowSequencesTableActions = ({
   table,
   enableKeyboardShortcuts,

--- a/src/routes/finder/src/components/FinderTable/FinderTable.tsx
+++ b/src/routes/finder/src/components/FinderTable/FinderTable.tsx
@@ -38,6 +38,7 @@ import { EmptyState } from '../EmptyState/EmptyState';
 import { computeFinderData } from './computeFinderData';
 import { TaskTableActions } from '../Actions/TaskActions';
 import { computeFinderColumns } from './computeFinderColumns';
+import { FlowSequencesTableActions } from '../Actions/FlowsActions';
 import { ContactTableActions, OrganizationTableActions } from '../Actions';
 
 export const FinderTable = observer(() => {
@@ -514,6 +515,16 @@ export const FinderTable = observer(() => {
                   !isEditing &&
                   !isCommandMenuPrompted
                 }
+              />
+            );
+          }
+
+          if (tableType === TableViewType.Flow) {
+            return (
+              <FlowSequencesTableActions
+                table={table}
+                selection={selectedIds}
+                focusedId={focusRow !== null ? data?.[focusRow]?.id : null}
               />
             );
           }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reintroduces `FlowSequencesTableActions` in `FinderTable.tsx` to handle flow-specific table actions and command menu types in `FlowsActions.tsx`.
> 
>   - **Behavior**:
>     - Reintroduces `FlowSequencesTableActions` in `FinderTable.tsx` for handling flow-specific table actions.
>     - Handles `Flow` and `Flows` command menu types based on selection count in `FlowsActions.tsx`.
>   - **Components**:
>     - Adds `FlowSequencesTableActions` to `renderTableActions` in `FinderTable.tsx` for `TableViewType.Flow`.
>   - **Misc**:
>     - Removes `@deprecated` comment from `FlowSequencesTableActions` in `FlowsActions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for a44ae409b8fa7a0b593793846bab131f201a24fa. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->