### PR TITLE
patch: loosen up frame ancestors

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,7 +8,7 @@ server {
 
   add_header X-Frame-Options "DENY" always;
   add_header X-Content-Type-Options "nosniff";
-  add_header Content-Security-Policy "default-src 'self' http: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.customeros.dev *.customeros.ai *.atlas.so unpkg.com *.heapanalytics.com *.clarity.ms *.stripe.com *.stripe.network *.posthog.com; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' *.customeros.dev *.customeros.ai *.atlas.so *.highlight.io *.heapanalytics.com *.stripe.com *.clarity.ms *.growthbook.io wss://real.customeros.dev wss://real.customeros.ai wss://app.atlas.so https://fonts.gstatic.com https://api.integration.app *.posthog.com; worker-src 'self' data: blob: http: https:; media-src 'self' data: http: https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self';" always;
+  add_header Content-Security-Policy "default-src 'self' http: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.customeros.dev *.customeros.ai *.atlas.so unpkg.com *.heapanalytics.com *.clarity.ms *.stripe.com *.stripe.network *.posthog.com; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' *.customeros.dev *.customeros.ai *.atlas.so *.highlight.io *.heapanalytics.com *.stripe.com *.clarity.ms *.growthbook.io wss://real.customeros.dev wss://real.customeros.ai wss://app.atlas.so https://fonts.gstatic.com https://api.integration.app *.posthog.com; worker-src 'self' data: blob: http: https:; media-src 'self' data: http: https:; object-src 'none'; frame-ancestors '*'; base-uri 'self';" always;
 
   location ~ /\. {
       deny all;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Loosen `frame-ancestors` in `nginx.conf` to allow any origin in `Content-Security-Policy`.
> 
>   - **Security Policy**:
>     - In `nginx.conf`, `frame-ancestors` directive in `Content-Security-Policy` changed from `'self'` to `'*'`, allowing any origin to frame the content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 1549c839ac29266d6802222f92239859b1fc70cb. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->