### PR TITLE
patch: losen csp rules for iframe

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -6,9 +6,9 @@ server {
   proxy_buffer_size 128k;
   large_client_header_buffers 16 32k;
 
-  add_header X-Frame-Options "DENY" always;
+  add_header X-Frame-Options "ALLOWALL" always;
   add_header X-Content-Type-Options "nosniff";
-  add_header Content-Security-Policy "default-src 'self' http: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.customeros.dev *.customeros.ai *.atlas.so unpkg.com *.heapanalytics.com *.clarity.ms *.stripe.com *.stripe.network *.posthog.com; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' *.customeros.dev *.customeros.ai *.atlas.so *.highlight.io *.heapanalytics.com *.stripe.com *.clarity.ms *.growthbook.io wss://real.customeros.dev wss://real.customeros.ai wss://app.atlas.so https://fonts.gstatic.com https://api.integration.app *.posthog.com; worker-src 'self' data: blob: http: https:; media-src 'self' data: http: https:; object-src 'none'; frame-ancestors '*'; base-uri 'self';" always;
+  add_header Content-Security-Policy "default-src 'self' http: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' *.customeros.dev *.customeros.ai *.atlas.so unpkg.com *.heapanalytics.com *.clarity.ms *.stripe.com *.stripe.network *.posthog.com; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' *.customeros.dev *.customeros.ai *.atlas.so *.highlight.io *.heapanalytics.com *.stripe.com *.clarity.ms *.growthbook.io wss://real.customeros.dev wss://real.customeros.ai wss://app.atlas.so https://fonts.gstatic.com https://api.integration.app *.posthog.com; worker-src 'self' data: blob: http: https:; media-src 'self' data: http: https:; object-src 'none'; base-uri 'self';" always;
 
   location ~ /\. {
       deny all;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Loosen iframe embedding restrictions by changing `X-Frame-Options` to `ALLOWALL` and removing `frame-ancestors` from CSP in `nginx.conf`.
> 
>   - **Security Headers**:
>     - Change `X-Frame-Options` from `DENY` to `ALLOWALL` in `nginx.conf` to allow embedding in iframes.
>     - Remove `frame-ancestors '*'` directive from `Content-Security-Policy` in `nginx.conf` to adjust iframe embedding rules.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for b5951de73b649ab265e6420db5c5b910474e004f. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->