### PR TITLE
patch: shod calendar nav items

### DIFF
--- a/src/routes/settings/src/components/SettingsSidenav/components/PersonalSection/PersonalSection.tsx
+++ b/src/routes/settings/src/components/SettingsSidenav/components/PersonalSection/PersonalSection.tsx
@@ -30,11 +30,11 @@ export const PersonalSection = ({
           isActive={checkIsActive('mailboxes')}
           onClick={handleItemClick('mailboxes')}
         />
-        {/* <SidenavItem
+        <SidenavItem
           label='Calendar'
           isActive={checkIsActive('calendar')}
           onClick={handleItemClick('calendar')}
-        /> */}
+        />
       </div>
     </div>
   );

--- a/src/routes/settings/src/components/SettingsSidenav/components/WorkspaceSection/WorkspaceSection.tsx
+++ b/src/routes/settings/src/components/SettingsSidenav/components/WorkspaceSection/WorkspaceSection.tsx
@@ -30,11 +30,11 @@ export const WorkspaceSection = ({
           isActive={checkIsActive('members')}
           onClick={handleItemClick('members')}
         />
-        {/* <SidenavItem
+        <SidenavItem
           label='Team scheduling'
           isActive={checkIsActive('team-scheduling')}
           onClick={handleItemClick('team-scheduling')}
-        /> */}
+        />
         <SidenavItem
           label='Tags'
           isActive={checkIsActive('tags')}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Re-enables 'Calendar' and 'Team scheduling' navigation items in settings sidebar.
> 
>   - **Behavior**:
>     - Re-enables `SidenavItem` for 'Calendar' in `PersonalSection.tsx`.
>     - Re-enables `SidenavItem` for 'Team scheduling' in `WorkspaceSection.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 7b603458d313c7119b67d4e13c6d14198b0b8f9c. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->