### PR TITLE
patch: upload to cdn workflow

### DIFF
--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -1,0 +1,20 @@
+name: Upload script to CDN
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - ./public/scripts/**
+
+jobs:
+  upload-to-cdn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy Script to Bunny Edge Scripting
+        uses: BunnyWay/actions/deploy-script@main
+        with:
+          script_id: ${{ secrets.BOOKING_SCRIPT_CDN_ID }}
+          deploy_key: ${{ secrets.CDN_DEPLOY_KEY }}
+          file: './public/scripts/booking-0.js'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a GitHub Actions workflow to upload scripts to CDN on push to main branch.
> 
>   - **Workflow Addition**:
>     - Adds `.github/workflows/cdn.yml` to automate script uploads to CDN.
>     - Triggers on push to `main` branch for changes in `./public/scripts/**`.
>   - **Deployment Job**:
>     - Job `upload-to-cdn` runs on `ubuntu-latest`.
>     - Uses `actions/checkout@v4` to check out the repository.
>     - Deploys `./public/scripts/booking-0.js` to Bunny Edge Scripting using `BunnyWay/actions/deploy-script@main`.
>     - Utilizes `secrets.BOOKING_SCRIPT_CDN_ID` and `secrets.CDN_DEPLOY_KEY` for authentication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 1812c76a53c5b3ffb18eb1acdc6fadc4596af2c8. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->