### PR TITLE
patch:fix border in website tracker view

### DIFF
--- a/src/routes/settings/src/components/Tabs/panels/Workspace/WebsiteTracker/WebsiteTracker.tsx
+++ b/src/routes/settings/src/components/Tabs/panels/Workspace/WebsiteTracker/WebsiteTracker.tsx
@@ -33,7 +33,7 @@ export const WebsiteTracker = observer(() => {
 
   return (
     <>
-      <div className='px-4 pb-4 flex flex-col  max-w-[448px] text-sm border-r overflow-y-auto max-h-[calc(100vh-1px)]'>
+      <div className='px-4 pb-4 flex flex-col max-w-[448px] h-full text-sm border-r overflow-y-auto max-h-[calc(100vh-1px)]'>
         <div className=' pt-1 flex justify-between items-center sticky top-0 bg-white z-10'>
           <h1 className='font-medium text-base'> Website tracker</h1>
           <Button


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `h-full` to `WebsiteTracker` component's `div` for full height usage.
> 
>   - **CSS Adjustment**:
>     - In `WebsiteTracker.tsx`, added `h-full` to the `div` to ensure it uses full height, potentially affecting layout and scrolling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for f70f8202432fe7fbeebbd1c1fd67911a193844f3. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->