### PR TITLE
patch: Fix incorrect key for ContactsTags filter type

### DIFF
--- a/src/routes/finder/src/components/Columns/contacts/filterTypes.tsx
+++ b/src/routes/finder/src/components/Columns/contacts/filterTypes.tsx
@@ -198,7 +198,7 @@ export const getFilterTypes = (store?: RootStore) => {
         <LinkedinOutline className='group-hover:text-grayModern-700grayModernt-grayModern-500 mb-0.5' />
       ),
     },
-    [ColumnViewType.ContactsPersona]: {
+    [ColumnViewType.ContactsTags]: {
       filterType: 'list',
       filterName: 'Tags',
       filterAccesor: ColumnViewType.ContactsPersona,

--- a/src/routes/finder/src/components/Columns/contacts/filterTypes.tsx
+++ b/src/routes/finder/src/components/Columns/contacts/filterTypes.tsx
@@ -201,7 +201,7 @@ export const getFilterTypes = (store?: RootStore) => {
     [ColumnViewType.ContactsTags]: {
       filterType: 'list',
       filterName: 'Tags',
-      filterAccesor: ColumnViewType.ContactsPersona,
+      filterAccesor: ColumnViewType.ContactsTags,
       filterOperators: [
         ComparisonOperator.In,
         ComparisonOperator.NotIn,

--- a/src/store/Contacts/__views__/filterFns.ts
+++ b/src/store/Contacts/__views__/filterFns.ts
@@ -145,7 +145,7 @@ const getFilterFn = (
       )
 
       .with(
-        { property: ColumnViewType.ContactsPersona },
+        { property: ColumnViewType.ContactsTags },
         (filter) => (row: Contact) => {
           if (!filter.active) return true;
           // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix incorrect key for `ContactsTags` filter type in `filterTypes.tsx` and `filterFns.ts`.
> 
>   - **Behavior**:
>     - Fix incorrect key for `ContactsTags` filter type in `filterTypes.tsx` and `filterFns.ts`.
>     - Change key from `ColumnViewType.ContactsPersona` to `ColumnViewType.ContactsTags`.
>   - **Files Affected**:
>     - `filterTypes.tsx`: Corrects the key for `ContactsTags` filter type.
>     - `filterFns.ts`: Updates the filter function to use the correct `ContactsTags` key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 695487ad545aee73c078523c23324a4dcf5a0a70. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->