### PR TITLE
patch: Add qualification status and qualifiedBy fields to organization

### DIFF
--- a/src/domain/entities/organization.entity.ts
+++ b/src/domain/entities/organization.entity.ts
@@ -7,10 +7,12 @@ import { OrganizationDatum } from '@/infra/repositories/core/organization';
 import {
   IcpFit,
   Market,
+  QualifiedBy,
   FundingRound,
   OnboardingStatus,
   OrganizationStage,
   LastTouchpointType,
+  QualificationStatus,
   OrganizationSaveInput,
   OrganizationRelationship,
   OpportunityRenewalLikelihood,
@@ -81,6 +83,9 @@ export class Organization implements OrganizationDatum {
   industryCode: OrganizationDatum['industryCode'] = '';
   industryName: OrganizationDatum['industryName'] = '';
   icpFitUpdatedAt: OrganizationDatum['icpFitUpdatedAt'] = null;
+  qualifiedBy: OrganizationDatum['qualifiedBy'] = QualifiedBy.None;
+  qualificationStatus: OrganizationDatum['qualificationStatus'] =
+    QualificationStatus.Pending;
 
   constructor(data?: Partial<OrganizationDatum>) {
     if (data) {

--- a/src/domain/usecases/command-menu/organization/add-search-organizations.usecase.ts
+++ b/src/domain/usecases/command-menu/organization/add-search-organizations.usecase.ts
@@ -277,8 +277,7 @@ export class AddSearchOrganizationsUsecase {
           ],
         },
         () => ({
-          relationship: OrganizationRelationship.Customer,
-          stage: OrganizationStage.Onboarding,
+          stage: OrganizationStage.Target,
         }),
       )
       .with(

--- a/src/infra/repositories/core/organization/queries/getOrganizationsByIds.generated.ts
+++ b/src/infra/repositories/core/organization/queries/getOrganizationsByIds.generated.ts
@@ -1,8 +1,106 @@
 import * as Types from '../../../../../routes/src/types/__generated__/graphql.types';
 
 export type GetOrganizationsByIdsQueryVariables = Types.Exact<{
-  ids?: Types.InputMaybe<Array<Types.Scalars['ID']['input']> | Types.Scalars['ID']['input']>;
+  ids?: Types.InputMaybe<
+    Array<Types.Scalars['ID']['input']> | Types.Scalars['ID']['input']
+  >;
 }>;
 
-
-export type GetOrganizationsByIdsQuery = { __typename?: 'Query', ui_organizations: Array<{ __typename?: 'OrganizationUiDetails', id: string, name: string, notes?: string | null, description?: string | null, industryName?: string | null, industryCode?: string | null, market?: Types.Market | null, website?: string | null, logoUrl?: string | null, iconUrl?: string | null, public?: boolean | null, stage?: Types.OrganizationStage | null, relationship?: Types.OrganizationRelationship | null, lastFundingRound?: Types.FundingRound | null, leadSource?: string | null, slackChannelId?: string | null, employees?: any | null, yearFounded?: any | null, enrichedAt?: any | null, enrichedFailedAt?: any | null, enrichedRequestedAt?: any | null, ltv?: number | null, hide: boolean, domains: Array<string>, icpFit?: Types.IcpFit | null, icpFitReasons: Array<string>, icpFitUpdatedAt?: any | null, wrongIndustry: boolean, createdAt: any, updatedAt: any, churnedAt?: any | null, customerOsId: string, referenceId: string, renewalSummaryArrForecast?: number | null, renewalSummaryMaxArrForecast?: number | null, renewalSummaryRenewalLikelihood?: Types.OpportunityRenewalLikelihood | null, renewalSummaryNextRenewalAt?: any | null, onboardingStatus: Types.OnboardingStatus, onboardingStatusUpdatedAt?: any | null, onboardingComments?: string | null, lastTouchPointAt?: any | null, lastTouchPointType?: Types.LastTouchpointType | null, contactCount?: number | null, parentId?: string | null, parentName?: string | null, contracts: Array<string>, contacts: Array<string>, subsidiaries: Array<string>, domainsDetails: Array<{ __typename?: 'Domain', domain: string, primary?: boolean | null, primaryDomain?: string | null }>, socialMedia: Array<{ __typename?: 'Social', id: string, url: string, alias: string, followersCount: any }>, tags: Array<{ __typename?: 'Tag', name: string, entityType: Types.EntityType, colorCode: string, metadata: { __typename?: 'Metadata', id: string } }>, locations: Array<{ __typename?: 'Location', id: string, name?: string | null, country?: string | null, region?: string | null, locality?: string | null, zip?: string | null, street?: string | null, postalCode?: string | null, houseNumber?: string | null, rawAddress?: string | null, countryCodeA2?: string | null, countryCodeA3?: string | null }>, owner?: { __typename?: 'User', id: string, firstName: string, lastName: string, name?: string | null } | null }> };
+export type GetOrganizationsByIdsQuery = {
+  __typename?: 'Query';
+  ui_organizations: Array<{
+    __typename?: 'OrganizationUiDetails';
+    id: string;
+    name: string;
+    notes?: string | null;
+    description?: string | null;
+    industryName?: string | null;
+    industryCode?: string | null;
+    market?: Types.Market | null;
+    website?: string | null;
+    logoUrl?: string | null;
+    iconUrl?: string | null;
+    public?: boolean | null;
+    stage?: Types.OrganizationStage | null;
+    relationship?: Types.OrganizationRelationship | null;
+    lastFundingRound?: Types.FundingRound | null;
+    leadSource?: string | null;
+    slackChannelId?: string | null;
+    employees?: any | null;
+    yearFounded?: any | null;
+    enrichedAt?: any | null;
+    qualificationStatus?: Types.QualificationStatus | null;
+    qualifiedBy?: Types.QualifiedBy | null;
+    enrichedFailedAt?: any | null;
+    enrichedRequestedAt?: any | null;
+    ltv?: number | null;
+    hide: boolean;
+    domains: Array<string>;
+    icpFit?: Types.IcpFit | null;
+    icpFitReasons: Array<string>;
+    icpFitUpdatedAt?: any | null;
+    wrongIndustry: boolean;
+    createdAt: any;
+    updatedAt: any;
+    churnedAt?: any | null;
+    customerOsId: string;
+    referenceId: string;
+    renewalSummaryArrForecast?: number | null;
+    renewalSummaryMaxArrForecast?: number | null;
+    renewalSummaryRenewalLikelihood?: Types.OpportunityRenewalLikelihood | null;
+    renewalSummaryNextRenewalAt?: any | null;
+    onboardingStatus: Types.OnboardingStatus;
+    onboardingStatusUpdatedAt?: any | null;
+    onboardingComments?: string | null;
+    lastTouchPointAt?: any | null;
+    lastTouchPointType?: Types.LastTouchpointType | null;
+    contactCount?: number | null;
+    parentId?: string | null;
+    parentName?: string | null;
+    contracts: Array<string>;
+    contacts: Array<string>;
+    subsidiaries: Array<string>;
+    domainsDetails: Array<{
+      __typename?: 'Domain';
+      domain: string;
+      primary?: boolean | null;
+      primaryDomain?: string | null;
+    }>;
+    socialMedia: Array<{
+      __typename?: 'Social';
+      id: string;
+      url: string;
+      alias: string;
+      followersCount: any;
+    }>;
+    tags: Array<{
+      __typename?: 'Tag';
+      name: string;
+      entityType: Types.EntityType;
+      colorCode: string;
+      metadata: { __typename?: 'Metadata'; id: string };
+    }>;
+    locations: Array<{
+      __typename?: 'Location';
+      id: string;
+      name?: string | null;
+      country?: string | null;
+      region?: string | null;
+      locality?: string | null;
+      zip?: string | null;
+      street?: string | null;
+      postalCode?: string | null;
+      houseNumber?: string | null;
+      rawAddress?: string | null;
+      countryCodeA2?: string | null;
+      countryCodeA3?: string | null;
+    }>;
+    owner?: {
+      __typename?: 'User';
+      id: string;
+      firstName: string;
+      lastName: string;
+      name?: string | null;
+    } | null;
+  }>;
+};

--- a/src/infra/repositories/core/organization/queries/getOrganizationsByIds.graphql
+++ b/src/infra/repositories/core/organization/queries/getOrganizationsByIds.graphql
@@ -19,6 +19,8 @@ query getOrganizationsByIds($ids: [ID!]) {
     employees
     yearFounded
     enrichedAt
+    qualificationStatus
+    qualifiedBy
     enrichedFailedAt
     enrichedRequestedAt
     ltv

--- a/src/routes/finder/src/components/Actions/OrganizationActions.tsx
+++ b/src/routes/finder/src/components/Actions/OrganizationActions.tsx
@@ -90,18 +90,12 @@ export const OrganizationTableActions = observer(
       if (!selectCount && !focusedId) return;
 
       if (!selectCount && focusedId) {
-        organizationService.setStageBulk(
-          [focusedId],
-          OrganizationStage.Unqualified,
-        );
+        organizationService.setStageBulk([focusedId], OrganizationStage.Target);
 
         return;
       }
 
-      organizationService.setStageBulk(
-        selection,
-        OrganizationStage.Unqualified,
-      );
+      organizationService.setStageBulk(selection, OrganizationStage.Target);
       clearSelection();
     };
 
@@ -123,12 +117,15 @@ export const OrganizationTableActions = observer(
       if (!selectCount && focusedId) {
         organizationService.setStageBulk(
           [focusedId],
-          OrganizationStage.Engaged,
+          OrganizationStage.Opportunity,
         );
 
         return;
       }
-      organizationService.setStageBulk(selection, OrganizationStage.Engaged);
+      organizationService.setStageBulk(
+        selection,
+        OrganizationStage.Opportunity,
+      );
       clearSelection();
     };
 

--- a/src/routes/settings/src/components/Tabs/panels/Fields/Organizations/fieldTypes.tsx
+++ b/src/routes/settings/src/components/Tabs/panels/Fields/Organizations/fieldTypes.tsx
@@ -159,24 +159,36 @@ export const getDefaultFieldTypes = (store?: RootStore) => {
       icon: <RadioButton />,
       options: [
         {
-          label: 'Lead',
-          id: OrganizationStage.Lead,
-        },
-        {
           label: 'Target',
           id: OrganizationStage.Target,
         },
         {
-          label: 'Engaged',
-          id: OrganizationStage.Engaged,
+          label: 'Education',
+          id: OrganizationStage.Education,
         },
         {
-          label: 'Trial',
-          id: OrganizationStage.Trial,
+          label: 'Solution',
+          id: OrganizationStage.Solution,
         },
         {
-          label: 'Unqualified',
-          id: OrganizationStage.Unqualified,
+          label: 'Evaluation',
+          id: OrganizationStage.Evaluation,
+        },
+        {
+          label: 'Ready to buy',
+          id: OrganizationStage.ReadyToBuy,
+        },
+        {
+          label: 'Opportunity',
+          id: OrganizationStage.Opportunity,
+        },
+        {
+          label: 'Customer',
+          id: OrganizationStage.Customer,
+        },
+        {
+          label: 'Not a fit',
+          id: OrganizationStage.NotAFit,
         },
       ],
     },

--- a/src/routes/src/components/CommandMenu/commands/OrganizationBulkCommands.tsx
+++ b/src/routes/src/components/CommandMenu/commands/OrganizationBulkCommands.tsx
@@ -147,7 +147,7 @@ export const OrganizationBulkCommands = observer(() => {
           onSelect={() => {
             organizationService.setStageBulk(
               selectedIds,
-              OrganizationStage.Engaged,
+              OrganizationStage.Opportunity,
             );
             store.ui.commandMenu.setOpen(false);
           }}

--- a/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
+++ b/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
@@ -14,12 +14,15 @@ import { Tag, TagLabel } from '@ui/presentation/Tag';
 import { Tooltip } from '@ui/overlay/Tooltip/Tooltip';
 import { SocialMediaList } from '@organization/components/Tabs';
 import { useCopyToClipboard } from '@shared/hooks/useCopyToClipboard';
-import { FlagWrongFields } from '@shared/types/__generated__/graphql.types';
 import { TruncatedText } from '@ui/presentation/TruncatedText/TruncatedText';
 import { IcpBadge } from '@shared/components/OrganizationDetails/components/icp';
 import { Domains } from '@shared/components/OrganizationDetails/components/domains';
 import { OwnerInput } from '@shared/components/OrganizationDetails/components/owner';
 import { AboutTabField } from '@shared/components/OrganizationDetails/components/AboutTabField';
+import {
+  FlagWrongFields,
+  QualificationStatus,
+} from '@shared/types/__generated__/graphql.types';
 
 import { Tags } from '../Tags';
 import { Documents } from './components/documents';
@@ -93,7 +96,10 @@ export const OrganizationDetails = observer(
                 </div>
               )}
 
-              <IcpBadge id={store.ui.focusRow ?? id} />
+              <IcpBadge
+                qualifiedBy={organization.qualifiedBy!}
+                qualificationStatus={QualificationStatus.Qualifying}
+              />
               {store.ui.showPreviewCard && (
                 <IconButton
                   size='xxs'

--- a/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
+++ b/src/routes/src/components/OrganizationDetails/OrganizationDetails.tsx
@@ -98,7 +98,7 @@ export const OrganizationDetails = observer(
 
               <IcpBadge
                 qualifiedBy={organization.qualifiedBy!}
-                qualificationStatus={QualificationStatus.Qualifying}
+                qualificationStatus={organization.qualificationStatus!}
               />
               {store.ui.showPreviewCard && (
                 <IconButton

--- a/src/routes/src/components/OrganizationDetails/components/icp/IcpBadge.tsx
+++ b/src/routes/src/components/OrganizationDetails/components/icp/IcpBadge.tsx
@@ -1,264 +1,79 @@
-import { useMemo, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-
 import { observer } from 'mobx-react-lite';
-import { registry } from '@domain/stores/registry';
-import { CreateAgentUsecase } from '@domain/usecases/agents/create-agent.usecase';
+import { Popover } from '@radix-ui/react-popover';
 
-import { cn } from '@ui/utils/cn';
+import { Icon } from '@ui/media/Icon';
 import { Spinner } from '@ui/feedback/Spinner';
-import { Icon, IconName } from '@ui/media/Icon';
 import { Button } from '@ui/form/Button/Button';
-import { useStore } from '@shared/hooks/useStore';
-import { IcpFit, AgentType } from '@graphql/types';
-import { Popover, PopoverContent, PopoverTrigger } from '@ui/overlay/Popover';
-import {
-  Tag,
-  TagLabel,
-  TagLeftIcon,
-  TagRightButton,
-} from '@ui/presentation/Tag';
-
-const icpData: Record<
-  IcpFit,
-  {
-    label: string;
-    icon?: IconName;
-    colorScheme: 'success' | 'warning' | 'grayModern';
-  }
-> = {
-  [IcpFit.IcpFit]: {
-    label: 'ICP match',
-    icon: 'check-verified-02',
-    colorScheme: 'success',
-  },
-  [IcpFit.IcpNotFit]: {
-    label: 'Not ICP',
-    icon: undefined,
-    colorScheme: 'warning',
-  },
-  [IcpFit.IcpNotSet]: {
-    label: 'ICP not set',
-    icon: undefined,
-    colorScheme: 'grayModern',
-  },
-};
-
-type PopoverState =
-  | { isMatch: boolean; reasons: string[]; type: 'has_reasons' }
-  | { type: 'agent_error' }
-  | { type: 'agent_inactive' }
-  | { type: 'profiling' }
-  | { type: 'manual_change' };
+import { Tag, TagLabel, TagProps } from '@ui/presentation/Tag';
+import { QualifiedBy, QualificationStatus } from '@graphql/types';
+import { PopoverContent, PopoverTrigger } from '@ui/overlay/Popover';
 
 interface IcpBadgeProps {
-  id: string;
+  qualifiedBy: QualifiedBy;
+  qualificationStatus: QualificationStatus;
 }
 
-export const IcpBadge = observer(({ id }: IcpBadgeProps) => {
-  const store = useStore();
-  const [open, setOpen] = useState(false);
+const complications: Record<
+  QualificationStatus,
+  [
+    label: string,
+    colorScheme: TagProps['colorScheme'],
+    leftElement: React.ReactElement,
+    rightElement?: React.ReactElement,
+    popoverContent?: React.ReactElement,
+  ]
+> = {
+  [QualificationStatus.Pending]: [
+    'Pending qualification',
+    'grayModern',
+    <Icon name='clock' />,
+  ],
+  [QualificationStatus.Qualified]: [
+    'ICP match',
+    'success',
+    <Icon name='check-verified-02' />,
+    <Icon name='chevron-right' />,
+  ],
+  [QualificationStatus.NotQualified]: [
+    'Not a fit',
+    'warning',
+    <Icon name='x-close' />,
+    <Icon name='chevron-right' />,
+  ],
+  [QualificationStatus.Qualifying]: [
+    'Qualifying',
+    'grayModern',
+    <Spinner
+      size='xs'
+      label='qualifying'
+      className='text-grayModern-300 fill-grayModern-500'
+    />,
+    undefined,
+    <div className='flex flex-col max-w-64 gap-4'>
+      <span className='text-sm'>
+        One moment... we are determining whether this lead fits your ICP
+      </span>
+      <Button size='xs' colorScheme='primary'>
+        See my ICP
+      </Button>
+    </div>,
+  ],
+};
 
-  const icpAgent = store.agents.getFirstAgentByType(AgentType.IcpQualifier);
-  const icpAgentActive = icpAgent?.value?.isActive;
-  const icpAgentHasError =
-    icpAgent?.value?.error !== null || !icpAgent?.value?.isConfigured;
-  const organization = registry.get('organizations').get(id);
-  const navigate = useNavigate();
-
-  const navigateToAgent = (id: string) => {
-    navigate(`/agents/${id}`);
-  };
-  const usecase = useMemo(() => new CreateAgentUsecase(navigateToAgent), []);
-
-  if (!organization) return null;
-
-  const data = organization.icpFit
-    ? icpData[organization.icpFit]
-    : icpData[IcpFit.IcpNotSet];
-
-  const handleAgentNavigation = () => {
-    if (!icpAgent) {
-      return usecase.execute(AgentType.IcpQualifier);
-    }
-
-    return navigate(`/agents/${icpAgent.id}`);
-  };
-
-  const getPopoverState = (): PopoverState => {
-    const { icpFitReasons, icpFit, icpFitUpdatedAt } = organization;
-
-    if (icpFitReasons.length > 0) {
-      return {
-        type: 'has_reasons',
-        reasons: icpFitReasons,
-        isMatch: icpFit === IcpFit.IcpFit,
-      };
-    }
-
-    if (icpAgentHasError) {
-      return { type: 'agent_error' };
-    }
-
-    if (!icpAgentActive || !icpAgent) {
-      return { type: 'agent_inactive' };
-    }
-
-    const isProfilingInProgress =
-      icpFit === IcpFit.IcpNotSet && !icpFitUpdatedAt;
-
-    if (isProfilingInProgress) {
-      return { type: 'profiling' };
-    }
-
-    return { type: 'manual_change' };
-  };
-
-  const popoverState = getPopoverState();
-  const showSpinner = popoverState.type === 'profiling';
+export const IcpBadge = observer(({ qualificationStatus }: IcpBadgeProps) => {
+  const [label, colorScheme, leftElement, rightElement, popoverContent] =
+    complications[qualificationStatus];
 
   return (
-    <Popover modal open={open} onOpenChange={setOpen}>
+    <Popover>
       <PopoverTrigger>
-        <Tag className='ml-4' variant='subtle' colorScheme={data.colorScheme}>
-          {data.icon && (
-            <TagLeftIcon className='mr-1'>
-              <div>
-                {showSpinner ? (
-                  <Spinner
-                    size='xs'
-                    label='icp profiling'
-                    className='text-grayModern-300 fill-grayModern-400'
-                  />
-                ) : (
-                  <Icon
-                    width={12}
-                    height={12}
-                    name={data.icon}
-                    className={cn('size-3 text-grayModern-500', {
-                      [`text-${data?.colorScheme}-500`]: true,
-                    })}
-                  />
-                )}
-              </div>
-            </TagLeftIcon>
-          )}
-
-          <TagLabel className='flex items-center whitespace-nowrap'>
-            {data.label}
+        <Tag colorScheme={colorScheme}>
+          <TagLabel className='flex items-center gap-1'>
+            {leftElement} {label} {rightElement}
           </TagLabel>
-          <TagRightButton>
-            <Icon
-              name={open ? 'chevron-up' : 'chevron-down'}
-              className={cn('text-grayModern-500 ml-0', {
-                [`text-${data?.colorScheme}-500`]: true,
-              })}
-            />
-          </TagRightButton>
         </Tag>
       </PopoverTrigger>
-      <PopoverContent align='end' side='bottom' className='text-sm'>
-        <div className='max-w-[295px]'>
-          <PopoverContents
-            state={popoverState}
-            agentId={icpAgent?.id}
-            onNavigate={handleAgentNavigation}
-          />
-        </div>
-      </PopoverContent>
+      <PopoverContent>{popoverContent}</PopoverContent>
     </Popover>
   );
 });
-
-const AgentLink = ({ agentId }: { agentId?: string }) => (
-  <Link
-    to={`/agents/${agentId}`}
-    className='mx-1 font-medium underline underline-offset-1 cursor-pointer'
-  >
-    ICP qualifier
-  </Link>
-);
-
-const QualifierButton = ({ onClick }: { onClick: () => void }) => (
-  <Button
-    size='xs'
-    variant='outline'
-    onClick={onClick}
-    colorScheme='primary'
-    className='w-full mt-4'
-  >
-    Go to ICP qualifier
-  </Button>
-);
-
-const PopoverContents = ({
-  state,
-  agentId,
-  onNavigate,
-}: {
-  agentId?: string;
-  state: PopoverState;
-  onNavigate: () => void;
-}) => {
-  switch (state.type) {
-    case 'has_reasons':
-      return (
-        <>
-          <p>
-            The <AgentLink agentId={agentId} /> agent determined that this
-            company {state.isMatch ? 'fits' : 'does not fit'} your ideal
-            customer profile.
-          </p>
-          <div className='pt-3'>
-            <span>Here's why:</span>
-            <ol className='list-decimal pl-5'>
-              {state.reasons.map((reason, index) => (
-                <li key={`${index}-reason`}>{reason}</li>
-              ))}
-            </ol>
-          </div>
-        </>
-      );
-
-    case 'agent_error':
-      return (
-        <>
-          <p>
-            To determine whether this company fits your ideal customer profile,
-            ensure the ICP qualifier agent is configured and enabled without
-            errors.
-          </p>
-          <QualifierButton onClick={onNavigate} />
-        </>
-      );
-
-    case 'agent_inactive':
-      return (
-        <>
-          <p>
-            To determine whether this company fits your ideal customer profile,
-            configure and enable the
-            <span className='mx-1 font-medium'>ICP qualifier</span>
-            agent.
-          </p>
-          <QualifierButton onClick={onNavigate} />
-        </>
-      );
-
-    case 'profiling':
-      return (
-        <p>
-          The <AgentLink agentId={agentId} /> agent is busy determining whether
-          this company fits your ideal customer profile or not
-        </p>
-      );
-
-    case 'manual_change':
-      return (
-        <p>
-          A user changed this company's ICP status by updating its relationship
-          and stage.
-        </p>
-      );
-  }
-};

--- a/src/routes/src/types/__generated__/graphql.types.ts
+++ b/src/routes/src/types/__generated__/graphql.types.ts
@@ -4030,6 +4030,8 @@ export type Organization = MetadataInterface & {
   parentCompanies: Array<LinkedOrganization>;
   phoneNumbers: Array<PhoneNumber>;
   public?: Maybe<Scalars['Boolean']['output']>;
+  qualificationStatus?: Maybe<QualificationStatus>;
+  qualifiedBy?: Maybe<QualifiedBy>;
   referenceId?: Maybe<Scalars['String']['output']>;
   /** @deprecated No longer supported */
   relationship?: Maybe<OrganizationRelationship>;
@@ -4203,21 +4205,12 @@ export type OrganizationSearchResult = {
 export enum OrganizationStage {
   Customer = 'CUSTOMER',
   Education = 'EDUCATION',
-  Engaged = 'ENGAGED',
   Evaluation = 'EVALUATION',
-  InitialValue = 'INITIAL_VALUE',
-  Lead = 'LEAD',
-  MaxValue = 'MAX_VALUE',
   NotAFit = 'NOT_A_FIT',
-  Onboarding = 'ONBOARDING',
   Opportunity = 'OPPORTUNITY',
-  PendingChurn = 'PENDING_CHURN',
   ReadyToBuy = 'READY_TO_BUY',
-  RecurringValue = 'RECURRING_VALUE',
   Solution = 'SOLUTION',
   Target = 'TARGET',
-  Trial = 'TRIAL',
-  Unqualified = 'UNQUALIFIED',
 }
 
 export type OrganizationTagInput = {
@@ -4268,7 +4261,10 @@ export type OrganizationUiDetails = {
   parentId?: Maybe<Scalars['ID']['output']>;
   parentName?: Maybe<Scalars['String']['output']>;
   public?: Maybe<Scalars['Boolean']['output']>;
+  qualificationStatus?: Maybe<QualificationStatus>;
+  qualifiedBy?: Maybe<QualifiedBy>;
   referenceId: Scalars['String']['output'];
+  /** @deprecated No longer supported */
   relationship?: Maybe<OrganizationRelationship>;
   renewalSummaryArrForecast?: Maybe<Scalars['Float']['output']>;
   renewalSummaryMaxArrForecast?: Maybe<Scalars['Float']['output']>;
@@ -4464,6 +4460,19 @@ export type PhoneNumberUpdateInput = {
   id: Scalars['ID']['input'];
   phoneNumber: Scalars['String']['input'];
 };
+
+export enum QualificationStatus {
+  NotQualified = 'NOT_QUALIFIED',
+  Pending = 'PENDING',
+  Qualified = 'QUALIFIED',
+  Qualifying = 'QUALIFYING',
+}
+
+export enum QualifiedBy {
+  None = 'NONE',
+  System = 'SYSTEM',
+  User = 'USER',
+}
 
 export type Query = {
   __typename?: 'Query';

--- a/src/ui/feedback/Spinner/Spinner.tsx
+++ b/src/ui/feedback/Spinner/Spinner.tsx
@@ -32,12 +32,12 @@ export const Spinner = ({ label, className, size }: SpinnerOptions) => {
   return (
     <div className='flex items-center'>
       <svg
-        fill='none'
         role='status'
         viewBox='0 0 100 101'
         xmlns='http://www.w3.org/2000/svg'
         className={twMerge(
-          `${className} inline animate-spin `,
+          className,
+          'inline animate-spin',
           spinnerSize({ className, size }),
         )}
       >


### PR DESCRIPTION
- Updated Organization entity with qualificationStatus and qualifiedBy fields.
- Extended GraphQL schema and queries to include new fields.
- Enhanced IcpBadge component to display qualification status.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `qualificationStatus` and `qualifiedBy` fields to `Organization` and update related components and queries.
> 
>   - **Entities**:
>     - Add `qualificationStatus` and `qualifiedBy` fields to `Organization` in `organization.entity.ts`.
>   - **GraphQL**:
>     - Extend `getOrganizationsByIds.graphql` and `getOrganizationsByIds.generated.ts` to include `qualificationStatus` and `qualifiedBy`.
>   - **Components**:
>     - Update `IcpBadge` in `IcpBadge.tsx` to display qualification status using new fields.
>     - Modify `OrganizationDetails.tsx` to pass `qualifiedBy` and `qualificationStatus` to `IcpBadge`.
>   - **Use Cases**:
>     - Change default `stage` in `add-search-organizations.usecase.ts` from `Onboarding` to `Target`.
>   - **UI**:
>     - Update `fieldTypes.tsx` to reflect new organization stages.
>     - Adjust `OrganizationActions.tsx` and `OrganizationBulkCommands.tsx` to use updated stages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for fa7955f95c75ca3a9a584cb561de96366298b162. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->