### PR TITLE
patch: fix overflow opportunities empty state + make searchBar same h…

### DIFF
--- a/src/routes/finder/src/components/EmptyState/EmptyState.tsx
+++ b/src/routes/finder/src/components/EmptyState/EmptyState.tsx
@@ -142,7 +142,7 @@ export const EmptyState = observer(() => {
   })();
 
   return (
-    <div className='flex justify-center h-full bg-white w-full'>
+    <div className='flex justify-center bg-white w-full'>
       <div className='flex flex-col h-[500px] w-[500px]'>
         <div className='flex relative'>
           <EmptyTable className='w-[152px] h-[120px] absolute top-[25%] right-[35%]' />

--- a/src/routes/finder/src/components/Search/Search.tsx
+++ b/src/routes/finder/src/components/Search/Search.tsx
@@ -103,7 +103,12 @@ export const Search = observer(() => {
   return (
     <div
       ref={wrapperRef}
-      className='flex items-center justify-between pr-1 py-[5px] mb-[1px] w-full gap-2 bg-white border-b'
+      className={cn(
+        'flex items-center justify-between pr-1 py-[5px] mb-[1px] w-full gap-2 bg-white border-b',
+        (tableViewDef?.value.tableId === TableIdType.Customers ||
+          !tableViewDef?.value.isPreset) &&
+          'py-[7px]',
+      )}
     >
       <div className='flex items-center gap-3 w-full'>
         <div className='flex items-center gap-4'>

--- a/src/routes/prospects/src/components/Search/Search.tsx
+++ b/src/routes/prospects/src/components/Search/Search.tsx
@@ -53,7 +53,7 @@ export const Search = observer(() => {
   return (
     <div
       ref={wrapperRef}
-      className='flex items-center justify-between pr-1 w-full gap-2 bg-white'
+      className='flex items-center justify-between pr-1 w-full gap-2 bg-white py-[1.5px]'
     >
       <InputGroup className='relative w-full bg-transparent hover:border-transparent focus-within:border-transparent focus-within:hover:border-transparent gap-1'>
         <LeftElement className='flex items-center gap-1'>

--- a/src/routes/src/components/Layout/Layout.tsx
+++ b/src/routes/src/components/Layout/Layout.tsx
@@ -70,7 +70,7 @@ export const Layout = () => {
         className='w-screen h-screen'
       >
         {sidenav}
-        <div className='h-full w-full flex-col overflow-hidden flex '>
+        <div className='h-full w-full flex-col overflow-hidden flex bg-white  '>
           <Outlet />
         </div>
       </PageLayout>


### PR DESCRIPTION
…eight all over the finder view
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix overflow in `EmptyState.tsx` and ensure consistent search bar height across views by adjusting CSS classes.
> 
>   - **UI Adjustments**:
>     - In `EmptyState.tsx`, removed `h-full` class from the outer `div` to fix overflow issues.
>     - In `Search.tsx` (finder), adjusted `py` class to `py-[7px]` for `Customers` and non-preset tables for consistent height.
>     - In `Search.tsx` (prospects), added `py-[1.5px]` to the `div` for consistent height.
>   - **Layout Changes**:
>     - In `Layout.tsx`, added `bg-white` class to the main content `div` for consistent background color.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 7838a618b43a7766303de318edc72e96fa210e5a. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->