### PR TITLE
feat: Add user profile photo handling and API proxy

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -356,6 +356,19 @@ async function createServer() {
     followRedirects: true,
   });
 
+  const filesApiProxyForUser = createProxyMiddleware({
+    pathFilter: '/user-logo',
+    pathRewrite: { '^/user-logo': '' },
+    target: process.env.CUSTOMER_OS_API_PATH + '/files/v1/user-profile-photo',
+    changeOrigin: true,
+    headers: {
+      'X-Openline-API-KEY': process.env.INTERNAL_API_KEY,
+    },
+    logger: console,
+    preserveHeaderKeyCase: true,
+    followRedirects: true,
+  });
+
   app.use(mailstackApiGqlProxy);
   app.use(customerOsApiGqlProxy);
   app.use(customerOsApiRestProxy);
@@ -363,6 +376,7 @@ async function createServer() {
   app.use(internalApiProxy);
   app.use(filesApiProxy);
   app.use(filesApiProxyForTenant);
+  app.use(filesApiProxyForUser);
   app.use(basConfigProxy);
   app.use(realtimeApiProxy);
   app.use(invoiceProxy);

--- a/src/domain/usecases/settings/profile/settings-profile.usecase.ts
+++ b/src/domain/usecases/settings/profile/settings-profile.usecase.ts
@@ -7,21 +7,13 @@ import { UsersService } from '@domain/services/users/users.service';
 export class SettingsProfileUseCase {
   private usersService = new UsersService();
   private root = RootStore.getInstance();
-  @observable private accessor userId: string = '';
+  @observable public accessor userId: string = '';
 
-  constructor() {
+  constructor(userId: string) {
     this.updateUserName = this.updateUserName.bind(this);
     this.updateUser = this.updateUser.bind(this);
-    this.init = this.init.bind(this);
     this.updateUserProfilePhotoUrl = this.updateUserProfilePhotoUrl.bind(this);
-  }
-
-  async init() {
-    const user = await this.usersService.getCurrentUser();
-
-    if (!user) return;
-
-    this.userId = user.user_Current.id;
+    this.userId = userId;
   }
 
   @computed
@@ -31,7 +23,7 @@ export class SettingsProfileUseCase {
 
   @computed
   get userProfilePhotoUrl() {
-    return this.root.users.getById(this.userId)?.value.profilePhotoUrl;
+    return this.root.users.getById(this.userId)?.value.profilePhotoUrlV2;
   }
 
   @action

--- a/src/infra/repositories/core/user/queries/getUsers.generated.ts
+++ b/src/infra/repositories/core/user/queries/getUsers.generated.ts
@@ -5,5 +5,26 @@ export type GetUsersQueryVariables = Types.Exact<{
   where?: Types.InputMaybe<Types.Filter>;
 }>;
 
-
-export type GetUsersQuery = { __typename?: 'Query', users: { __typename?: 'UserPage', totalElements: any, content: Array<{ __typename?: 'User', id: string, firstName: string, lastName: string, name?: string | null, profilePhotoUrl?: string | null, mailboxes: Array<string>, bot: boolean, internal: boolean, test: boolean, timezone?: string | null, hasLinkedInToken: boolean, emails?: Array<{ __typename?: 'Email', email?: string | null }> | null }> } };
+export type GetUsersQuery = {
+  __typename?: 'Query';
+  users: {
+    __typename?: 'UserPage';
+    totalElements: any;
+    content: Array<{
+      __typename?: 'User';
+      id: string;
+      firstName: string;
+      lastName: string;
+      name?: string | null;
+      profilePhotoUrl?: string | null;
+      profilePhotoUrlV2?: string | null;
+      mailboxes: Array<string>;
+      bot: boolean;
+      internal: boolean;
+      test: boolean;
+      timezone?: string | null;
+      hasLinkedInToken: boolean;
+      emails?: Array<{ __typename?: 'Email'; email?: string | null }> | null;
+    }>;
+  };
+};

--- a/src/infra/repositories/core/user/queries/getUsers.graphql
+++ b/src/infra/repositories/core/user/queries/getUsers.graphql
@@ -6,6 +6,7 @@ query getUsers($pagination: Pagination!, $where: Filter) {
       lastName
       name
       profilePhotoUrl
+      profilePhotoUrlV2
       mailboxes
       bot
       internal

--- a/src/store/Users/User.dto.ts
+++ b/src/store/Users/User.dto.ts
@@ -42,7 +42,7 @@ export class User extends Entity<UserDatum> {
   @action
   updateProfilePhotoUrl(url: string) {
     this.draft();
-    this.value.profilePhotoUrl = url;
+    this.value.profilePhotoUrlV2 = url;
     this.commit({ syncOnly: true });
   }
 


### PR DESCRIPTION
- Introduced a new proxy middleware for user profile photo uploads.
- Updated SettingsProfileUseCase to accept userId as a constructor parameter.
- Modified user profile photo URL handling to use profilePhotoUrlV2.
- Adjusted Profile component to utilize the new API endpoint for logo uploads.
- Enhanced GraphQL queries to include profilePhotoUrlV2 for users.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add proxy middleware for user profile photo uploads and update components to use new API endpoint and `profilePhotoUrlV2`.
> 
>   - **Middleware**:
>     - Added `filesApiProxyForUser` in `middleware/index.js` for handling `/user-logo` path, targeting `/files/v1/user-profile-photo`.
>   - **Use Case**:
>     - Updated `SettingsProfileUseCase` in `settings-profile.usecase.ts` to accept `userId` as a constructor parameter.
>     - Modified `userProfilePhotoUrl` to use `profilePhotoUrlV2`.
>   - **GraphQL**:
>     - Enhanced `getUsers` query in `getUsers.generated.ts` and `getUsers.graphql` to include `profilePhotoUrlV2`.
>   - **Components**:
>     - Adjusted `Profile.tsx` to use `/user-logo` API endpoint for uploads and display `profilePhotoUrlV2`.
>   - **Models**:
>     - Updated `User` class in `User.dto.ts` to use `profilePhotoUrlV2` for profile photo updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=customeros%2Ffrontera&utm_source=github&utm_medium=referral)<sup> for 9fab097c35d5570155a10578b2dbce2d63663aaa. You can [customize](https://app.ellipsis.dev/customeros/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->